### PR TITLE
Add labels to component props

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -22,10 +22,11 @@ function paramTypeToPropType(type) {
   return mapping[type];
 }
 
-function paramToProp(param, required) {
+function paramToProp(param, key, required) {
+  const label = param._label ?? `${key.charAt(0).toUpperCase()}${key.slice(1)}`.replace(/_/g, " ");
   return {
     type: paramTypeToPropType(param.type),
-    label: param._label,
+    label,
     description: param.description,
     optional: !required || undefined
   };
@@ -34,7 +35,7 @@ function paramToProp(param, required) {
 function paramsSchemaToProps(params) {
   return Object.entries(params.properties).map(([key, value]) => ({
     key,
-    ...paramToProp(value, params.required.includes(key)),
+    ...paramToProp(value, key, params.required.includes(key)),
   }));
 }
 


### PR DESCRIPTION
Converts param keys to prop labels by capitalizing the first character and removing underscores.

E.g., `email_address` -> `Email address`

Resolves #13 