### PR TITLE
Convert Pipedream primitives to $ functions

### DIFF
--- a/lib/collections/ArrowFunctionExpression.js
+++ b/lib/collections/ArrowFunctionExpression.js
@@ -3,9 +3,11 @@ const NodeCollection = require("jscodeshift/dist/collections/Node");
 const recast = require("recast");
 const once = require("lodash.once");
 
+const Node = require("./Node");
+
 const types = recast.types.namedTypes;
 
-const ArrowFunctionExpression = recast.types.namedTypes.ArrowFunctionExpression;
+const ArrowFunctionExpression = types.namedTypes.ArrowFunctionExpression;
 
 /**
 * @mixin
@@ -22,93 +24,39 @@ const traversalMethods = {
    * @return {Collection}
    */
   getVariableInstances: function(paramIdx, getSelf = false) {
-    let paths = [];
-    this.forEach(function(path) {
-      var node = path.value;
-      var oldName = node.params[paramIdx].name;
-      var rootScope = path.scope;
-      var rootPath = rootScope.path;
-      Collection.fromPaths([rootPath])
-        .find(types.Identifier, { name: oldName })
+    // let paths = [];
+    return this.map(function(path) {
+      const node = path.value;
+      return Collection.fromPaths([path], this)
+        .getVariableOccurences(node.params[paramIdx].name)
         .filter(function(path) { // ignore self unless getSelf
           return getSelf || path.parent.value !== node;
         })
-        .filter(function(path) { // ignore properties in MemberExpressions
-          var parent = path.parent.node;
-          return !types.MemberExpression.check(parent) ||
-              parent.property !== path.node ||
-              !parent.computed;
-        })
-        .filter(function(path) { // ignore property keys
-          var parent = path.parent.node;
-          return !types.Property.check(parent) ||
-              parent.key !== path.node;
-        })
-        .forEach(function(path) {
-          var scope = path.scope;
-          while (scope && scope !== rootScope) {
-            if (scope.declares(oldName)) {
-              return;
-            }
-            scope = scope.parent;
-          }
-          if (scope) { // identifier must refer to declared variable
-            paths.push(path);
-          }
-        });
+        .paths();
     });
-    return Collection.fromPaths(paths, this);
   },
 };
 
 const transformMethods = {
   /**
-   * Renames a variable and all its occurrences.
+   * Renames a variable and all its occurrences
    *
    * @param {string} newName
    * @return {Collection}
    */
   renameTo: function(paramIdx, newName, replaceSelf=false) {
     // TODO: Include JSXElements
-    return this.forEach(function(path) {
-      var node = path.value;
-      var oldName = node.params[paramIdx].name;
-      var rootScope = path.scope;
-      var rootPath = rootScope.path;
-      Collection.fromPaths([rootPath])
-        .find(types.Identifier, { name: oldName })
-        .filter(function(path) {
-          return replaceSelf || path.parent.value !== node;
-        })
-        .filter(function(path) { // ignore properties in MemberExpressions
-          var parent = path.parent.node;
-          return !types.MemberExpression.check(parent) ||
-            parent.property !== path.node ||
-            !parent.computed;
-        })
-        .filter(function(path) { // ignore property keys
-          var parent = path.parent.node;
-          return !types.Property.check(parent) ||
-            parent.key !== path.node;
-        })
-        .forEach(function(path) {
-          var scope = path.scope;
-          while (scope && scope !== rootScope) {
-            if (scope.declares(oldName)) {
-              return;
-            }
-            scope = scope.parent;
-          }
-          if (scope) { // identifier must refer to declared variable
-            path.get("name").replace(newName);
-          }
-        });
-    });
+    return this.
+      getVariableInstances(paramIdx, replaceSelf)
+      .forEach((path) => {
+        path.get("name").replace(newName);
+      });
   }
 };
 
 function register() {
   NodeCollection.register();
+  Node.register();
   Collection.registerMethods(traversalMethods, ArrowFunctionExpression);
   Collection.registerMethods(transformMethods, ArrowFunctionExpression);
 }

--- a/lib/collections/ArrowFunctionExpression.js
+++ b/lib/collections/ArrowFunctionExpression.js
@@ -7,7 +7,7 @@ const Node = require("./Node");
 
 const types = recast.types.namedTypes;
 
-const ArrowFunctionExpression = types.namedTypes.ArrowFunctionExpression;
+const ArrowFunctionExpression = types.ArrowFunctionExpression;
 
 /**
 * @mixin

--- a/lib/collections/ArrowFunctionExpression.js
+++ b/lib/collections/ArrowFunctionExpression.js
@@ -15,7 +15,7 @@ const ArrowFunctionExpression = types.ArrowFunctionExpression;
 const traversalMethods = {
 
   /**
-   * Find occurences of a variable from a function parameter
+   * Find occurrences of a variable from a function parameter
    *
    * @param {number} paramIdx - Index of the function parameter
    * @param {boolean} getSelf - Whether to include the function parameter in the
@@ -28,7 +28,7 @@ const traversalMethods = {
     return this.map(function(path) {
       const node = path.value;
       return Collection.fromPaths([path], this)
-        .getVariableOccurences(node.params[paramIdx].name)
+        .getVariableOccurrences(node.params[paramIdx].name)
         .filter(function(path) { // ignore self unless getSelf
           return getSelf || path.parent.value !== node;
         })

--- a/lib/collections/LegacyAction.js
+++ b/lib/collections/LegacyAction.js
@@ -18,7 +18,7 @@ const traversalMethods = {
   },
 
   /**
-   * Finds occurences of `auths` member expressions
+   * Finds occurrences of `auths` member expressions
    * 
    * `auths.__a`
    * 
@@ -32,7 +32,7 @@ const traversalMethods = {
   },
 
   /**
-   * Finds occurences of `auths` variable declarators
+   * Finds occurrences of `auths` variable declarators
    * 
    * `const { __a: __b } = auths`
    * 
@@ -47,7 +47,7 @@ const traversalMethods = {
   },
 
   /**
-   * Finds occurences of `this.$checkpoint` assignment expressions
+   * Finds occurrences of `this.$checkpoint` assignment expressions
    * 
    *  `this.$checkpoint = __a`
    * 
@@ -73,7 +73,7 @@ const traversalMethods = {
   },
 
   /**
-   * Finds occurences of `this.$checkpoint` expressions
+   * Finds occurrences of `this.$checkpoint` expressions
    * 
    * `this.$checkpoint` (not `__a = this.$checkpoint`)
    * 

--- a/lib/collections/LegacyAction.js
+++ b/lib/collections/LegacyAction.js
@@ -6,13 +6,17 @@ const { fromPaths } = require("jscodeshift/dist/Collection");
 
 const types = recast.types.namedTypes;
 
-const Node = recast.types.namedTypes.Node;
+const File = types.File;
 
 
 /**
 * @mixin
 */
 const traversalMethods = {
+  getFunctionExpression: function() {
+    return fromPaths([this.get("program", "body", 0, "expression")], this);
+  },
+
   /**
    * Finds occurences of `auths` member expressions
    * 
@@ -21,7 +25,7 @@ const traversalMethods = {
    * @return {Collection}
    */
   getAuthMemberExpressions: function() {
-    return fromPaths([this.get("program", "body", 0, "expression")], this)
+    return this.getFunctionExpression()
       .getVariableInstances(1)
       .map((path) => path.parent)
       .filter((path) => types.MemberExpression.check(path.value));
@@ -35,7 +39,7 @@ const traversalMethods = {
    * @return {Collection}
    */
   getAuthVariableDeclarators: function() {
-    return fromPaths([this.get("program", "body", 0, "expression")], this)
+    return this.getFunctionExpression()
       .getVariableInstances(1)
       .map((path) => path.parent)
       .filter((path) => types.VariableDeclarator.check(path.value))
@@ -94,7 +98,7 @@ const traversalMethods = {
 
 function register() {
   registerArrowFunctionExpression();
-  Collection.registerMethods(traversalMethods, Node);
+  Collection.registerMethods(traversalMethods, File);
 }
 
 exports.register = once(register);

--- a/lib/collections/Node.js
+++ b/lib/collections/Node.js
@@ -1,0 +1,103 @@
+const Collection = require("jscodeshift/dist/Collection");
+const NodeCollection = require("jscodeshift/dist/collections/Node");
+const recast = require("recast");
+const once = require("lodash.once");
+
+const types = recast.types.namedTypes;
+
+const Node = recast.types.namedTypes.Node;
+
+/**
+* @mixin
+*/
+const traversalMethods = {
+  /**
+   * Gets a variable's occurrences. Sourced from
+   * {@link https://bit.ly/3B4BwNa jscodeshift's GitHub Repo}.
+   *
+   * @param {string} varName
+   * @return {Collection}
+   */
+  getVariableOccurences: function(varName) {
+    // TODO: Include JSXElements
+    let paths = [];
+    this.forEach(function(path) {
+      // const node = path.value;
+      // const oldName = node.id.name;
+      const rootScope = path.scope;
+      const rootPath = rootScope.path;
+      Collection.fromPaths([rootPath])
+        .find(types.Identifier, { name: varName })
+        .filter(function(path) { // ignore non-variables
+          const parent = path.parent.node;
+
+          if (
+            types.MemberExpression.check(parent) &&
+            parent.property === path.node &&
+            !parent.computed
+          ) {
+            // obj.varName
+            return false;
+          }
+
+          if (
+            types.Property.check(parent) &&
+            parent.key === path.node &&
+            !parent.computed
+          ) {
+            // { varName: 3 }
+            return false;
+          }
+
+          if (
+            types.MethodDefinition.check(parent) &&
+            parent.key === path.node &&
+            !parent.computed
+          ) {
+            // class A { varName() {} }
+            return false;
+          }
+
+          if (
+            types.ClassProperty.check(parent) &&
+            parent.key === path.node &&
+            !parent.computed
+          ) {
+            // class A { varName = 3 }
+            return false;
+          }
+
+          if (
+            types.JSXAttribute.check(parent) &&
+            parent.name === path.node &&
+            !parent.computed
+          ) {
+            // <Foo varName={varName} />
+            return false;
+          }
+
+          return true;
+        })
+        .forEach(function(path) {
+          let scope = path.scope;
+          while (scope && scope !== rootScope) {
+            if (scope.declares(varName)) {
+              return;
+            }
+            scope = scope.parent;
+          }
+          if (scope) {
+            paths.push(path);
+          }
+        });
+    });
+    return Collection.fromPaths(paths, this);
+  }
+};
+
+function register() {
+  NodeCollection.register();
+  Collection.registerMethods(traversalMethods, Node);
+}
+
+exports.register = once(register);

--- a/lib/collections/Node.js
+++ b/lib/collections/Node.js
@@ -18,7 +18,7 @@ const traversalMethods = {
    * @param {string} varName
    * @return {Collection}
    */
-  getVariableOccurences: function(varName) {
+  getVariableOccurrences: function(varName) {
     // TODO: Include JSXElements
     let paths = [];
     this.forEach(function(path) {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -8,6 +8,7 @@ const programToExpression = require("./transforms/program-to-expression");
 const namedExportToDollarExport = require("./transforms/named-export-to-dollar-export");
 const sendToDotSend = require("./transforms/send-to-dot-send");
 const respondToDotRespond = require("./transforms/respond-to-dot-respond");
+const endToFlowExit = require("./transforms/end-to-flow-exit");
 
 
 function legacyToComponentCode(source) {
@@ -16,6 +17,7 @@ function legacyToComponentCode(source) {
   output = applyTransform(checkpointToDbGet, {}, { source: output });
   output = applyTransform(sendToDotSend, {}, { source: output });
   output = applyTransform(respondToDotRespond, {}, { source: output });
+  output = applyTransform(endToFlowExit, {}, { source: output });
   output = applyTransform(namedExportToDollarExport, {}, { source: output });
   output = applyTransform(paramsToProps, {}, { source: output });
   output = applyTransform(authsToAuth, {}, { source: output });

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -10,19 +10,26 @@ const sendToDotSend = require("./transforms/send-to-dot-send");
 const respondToDotRespond = require("./transforms/respond-to-dot-respond");
 const endToFlowExit = require("./transforms/end-to-flow-exit");
 
+function applyTransforms(source, transforms) {
+  let output = source;
+  for (const transform of transforms) {
+    output = applyTransform(transform, {}, { source: output });
+  }
+  return output;
+}
 
 function legacyToComponentCode(source) {
-  let output = source;
-  output = applyTransform(checkpointToDbSet, {}, { source: output });
-  output = applyTransform(checkpointToDbGet, {}, { source: output });
-  output = applyTransform(sendToDotSend, {}, { source: output });
-  output = applyTransform(respondToDotRespond, {}, { source: output });
-  output = applyTransform(endToFlowExit, {}, { source: output });
-  output = applyTransform(namedExportToDollarExport, {}, { source: output });
-  output = applyTransform(paramsToProps, {}, { source: output });
-  output = applyTransform(authsToAuth, {}, { source: output });
-  output = applyTransform(programToExpression, {}, { source: output });
-  return output;
+  return applyTransforms(source, [
+    checkpointToDbSet,
+    checkpointToDbGet,
+    sendToDotSend,
+    respondToDotRespond,
+    endToFlowExit,
+    namedExportToDollarExport,
+    paramsToProps,
+    authsToAuth,
+    programToExpression
+  ]);
 }
 
 function transform(source) {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -7,6 +7,7 @@ const authsToAuth = require("./transforms/auths-to-auth");
 const programToExpression = require("./transforms/program-to-expression");
 const namedExportToDollarExport = require("./transforms/named-export-to-dollar-export");
 const sendToDotSend = require("./transforms/send-to-dot-send");
+const respondToDotRespond = require("./transforms/respond-to-dot-respond");
 
 
 function legacyToComponentCode(source) {
@@ -14,6 +15,7 @@ function legacyToComponentCode(source) {
   output = applyTransform(checkpointToDbSet, {}, { source: output });
   output = applyTransform(checkpointToDbGet, {}, { source: output });
   output = applyTransform(sendToDotSend, {}, { source: output });
+  output = applyTransform(respondToDotRespond, {}, { source: output });
   output = applyTransform(namedExportToDollarExport, {}, { source: output });
   output = applyTransform(paramsToProps, {}, { source: output });
   output = applyTransform(authsToAuth, {}, { source: output });

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -6,12 +6,14 @@ const paramsToProps = require("./transforms/params-to-props");
 const authsToAuth = require("./transforms/auths-to-auth");
 const programToExpression = require("./transforms/program-to-expression");
 const namedExportToDollarExport = require("./transforms/named-export-to-dollar-export");
+const sendToDotSend = require("./transforms/send-to-dot-send");
 
 
 function legacyToComponentCode(source) {
   let output = source;
   output = applyTransform(checkpointToDbSet, {}, { source: output });
   output = applyTransform(checkpointToDbGet, {}, { source: output });
+  output = applyTransform(sendToDotSend, {}, { source: output });
   output = applyTransform(namedExportToDollarExport, {}, { source: output });
   output = applyTransform(paramsToProps, {}, { source: output });
   output = applyTransform(authsToAuth, {}, { source: output });

--- a/lib/transforms/auths-to-auth.js
+++ b/lib/transforms/auths-to-auth.js
@@ -1,7 +1,7 @@
 const { register } = require("../collections/LegacyAction");
 register();
 
-// replace `auths.github` with `this.github.$auth`
+// replace `auths.__a` with `this.__a.$auth`
 // replace `const { __a: __b } = auths` with `const __b = this.__a.$auth`
 
 module.exports = function(fileInfo, api, options) {

--- a/lib/transforms/checkpoint-to-db-get.js
+++ b/lib/transforms/checkpoint-to-db-get.js
@@ -11,14 +11,14 @@ module.exports = function(fileInfo, api, options) {
   ast
     .getCheckpointExpressions()
     .replaceWith(() => {
-      // this.db.get("$checkpoint");
+      // `this.db.get("$checkpoint")`
       return j.callExpression(
         j.memberExpression(
-          j.memberExpression(j.thisExpression(), j.identifier("db")), // this.db
-          j.identifier("get") // .get
-        ), [ // (
-          j.literal("$checkpoint"),  // "$checkpoint",
-        ] // )
+          j.memberExpression(j.thisExpression(), j.identifier("db")), // `this.db`
+          j.identifier("get") // `.get`
+        ), [ // `(`
+          j.literal("$checkpoint"),  // `"$checkpoint",`
+        ] // `)`
       );
     });
 

--- a/lib/transforms/checkpoint-to-db-set.js
+++ b/lib/transforms/checkpoint-to-db-set.js
@@ -11,15 +11,15 @@ module.exports = function(fileInfo, api, options) {
     .getCheckpointAssignmentExpressions()
     .replaceWith((path) => {
       const value = path.value.right;
-      // this.db.set("$checkpoint", value);
+      // `this.db.set("$checkpoint", value)`
       return j.callExpression(
         j.memberExpression(
-          j.memberExpression(j.thisExpression(), j.identifier("db")), // this.db
-          j.identifier("set") // .set
-        ), [ // (
-          j.literal("$checkpoint"),  // "$checkpoint",
-          value, // value
-        ] // )
+          j.memberExpression(j.thisExpression(), j.identifier("db")), // `this.db`
+          j.identifier("set") // `.set`
+        ), [ // `(`
+          j.literal("$checkpoint"),  // `"$checkpoint",`
+          value, // `value`
+        ] // `)`
       );
     });
 

--- a/lib/transforms/end-to-flow-exit.js
+++ b/lib/transforms/end-to-flow-exit.js
@@ -1,0 +1,20 @@
+const { register } = require("../collections/LegacyAction");
+register();
+
+// convert `$end` to `$.flow.exit`
+
+module.exports = function(fileInfo, api, options) {
+  const j = api.jscodeshift;
+
+  const ast = j(fileInfo.source)
+    .getFunctionExpression()
+    .getVariableOccurences("$end")
+    .replaceWith(() => {
+      return j.memberExpression(
+        j.memberExpression(j.identifier("$"), j.identifier("flow")),
+        j.identifier("exit")
+      );
+    });
+
+  return ast.toSource();
+};

--- a/lib/transforms/end-to-flow-exit.js
+++ b/lib/transforms/end-to-flow-exit.js
@@ -8,7 +8,7 @@ module.exports = function(fileInfo, api, options) {
 
   const ast = j(fileInfo.source)
     .getFunctionExpression()
-    .getVariableOccurences("$end")
+    .getVariableOccurrences("$end")
     .replaceWith(() => {
       return j.memberExpression(
         j.memberExpression(j.identifier("$"), j.identifier("flow")),

--- a/lib/transforms/named-export-to-dollar-export.js
+++ b/lib/transforms/named-export-to-dollar-export.js
@@ -1,8 +1,7 @@
-const { fromPaths } = require("jscodeshift/dist/Collection");
 const { register } = require("../collections/ArrowFunctionExpression");
 register();
 
-// convert `this.__a = __b` to `$.export(__a, __b)` when this is bound to root
+// convert `this.__a = __b` to `$.export(__a, __b)`
 
 module.exports = function(fileInfo, api, options) {
   const j = api.jscodeshift;

--- a/lib/transforms/params-to-props.js
+++ b/lib/transforms/params-to-props.js
@@ -1,14 +1,11 @@
-const { fromPaths } = require("jscodeshift/dist/Collection");
-const { register } = require("../collections/ArrowFunctionExpression");
+const { register } = require("../collections/LegacyAction");
 register();
 
 module.exports = function(fileInfo, api, options) {
   const j = api.jscodeshift;
 
-  const ast = j(fileInfo.source);
-  const functionExpr = fromPaths([ast.get("program", "body", 0, "expression")], ast);
-
-  return functionExpr
+  return j(fileInfo.source)
+    .getFunctionExpression()
     .renameTo(0, "this")
     .toSource();
 };

--- a/lib/transforms/program-to-expression.js
+++ b/lib/transforms/program-to-expression.js
@@ -1,7 +1,9 @@
+const { register } = require("../collections/LegacyAction");
+register();
+
 module.exports = function(fileInfo, api, options) {
   const j = api.jscodeshift;
 
   const ast = j(fileInfo.source);
-  return j(ast.get("program", "body", 0, "expression", "body"))
-    .toSource();
+  return j(ast.getFunctionExpression().get("body")).toSource();
 };

--- a/lib/transforms/respond-to-dot-respond.js
+++ b/lib/transforms/respond-to-dot-respond.js
@@ -1,0 +1,17 @@
+const { register } = require("../collections/LegacyAction");
+register();
+
+// convert `$respond` to `$.respond`
+
+module.exports = function(fileInfo, api, options) {
+  const j = api.jscodeshift;
+
+  const ast = j(fileInfo.source)
+    .getFunctionExpression()
+    .getVariableOccurences("$respond")
+    .replaceWith(() => {
+      return j.memberExpression(j.identifier("$"), j.identifier("respond"));
+    });
+
+  return ast.toSource();
+};

--- a/lib/transforms/respond-to-dot-respond.js
+++ b/lib/transforms/respond-to-dot-respond.js
@@ -8,7 +8,7 @@ module.exports = function(fileInfo, api, options) {
 
   const ast = j(fileInfo.source)
     .getFunctionExpression()
-    .getVariableOccurences("$respond")
+    .getVariableOccurrences("$respond")
     .replaceWith(() => {
       return j.memberExpression(j.identifier("$"), j.identifier("respond"));
     });

--- a/lib/transforms/send-to-dot-send.js
+++ b/lib/transforms/send-to-dot-send.js
@@ -8,7 +8,7 @@ module.exports = function(fileInfo, api, options) {
 
   const ast = j(fileInfo.source)
     .getFunctionExpression()
-    .getVariableOccurences("$send")
+    .getVariableOccurrences("$send")
     .replaceWith(() => {
       return j.memberExpression(j.identifier("$"), j.identifier("send"));
     });

--- a/lib/transforms/send-to-dot-send.js
+++ b/lib/transforms/send-to-dot-send.js
@@ -1,0 +1,20 @@
+const { fromPaths } = require("jscodeshift/dist/Collection");
+const { register } = require("../collections/Node");
+register();
+
+// convert $send to $.send
+
+module.exports = function(fileInfo, api, options) {
+  const j = api.jscodeshift;
+
+  const ast = j(fileInfo.source);
+  const functionExpr = fromPaths([ast.get("program", "body", 0, "expression")], ast);
+
+  functionExpr
+    .getVariableOccurences("$send")
+    .replaceWith(() => {
+      return j.memberExpression(j.identifier("$"), j.identifier("send"));
+    });
+
+  return ast.toSource();
+};

--- a/lib/transforms/send-to-dot-send.js
+++ b/lib/transforms/send-to-dot-send.js
@@ -1,16 +1,13 @@
-const { fromPaths } = require("jscodeshift/dist/Collection");
-const { register } = require("../collections/Node");
+const { register } = require("../collections/LegacyAction");
 register();
 
-// convert $send to $.send
+// convert `$send` to `$.send`
 
 module.exports = function(fileInfo, api, options) {
   const j = api.jscodeshift;
 
-  const ast = j(fileInfo.source);
-  const functionExpr = fromPaths([ast.get("program", "body", 0, "expression")], ast);
-
-  functionExpr
+  const ast = j(fileInfo.source)
+    .getFunctionExpression()
     .getVariableOccurences("$send")
     .replaceWith(() => {
       return j.memberExpression(j.identifier("$"), j.identifier("send"));


### PR DESCRIPTION
- Converts `$send` -> `$.send`
- Converts `$respond` -> `$.respond`
- Converts `$end` -> `$.flow.exit`
- Refactors getting the ArrowFunctionExpression node from the AST
- Refactors getting a Collection of variable occurrences

Resolves #7 