### PR TITLE
Add option to generate component prop labels

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -39,6 +39,12 @@ async function prompt() {
       message: "Wrap the component with `defineComponent()`?",
       default: false,
     },
+    {
+      type: "confirm",
+      name: "createLabel",
+      message: "Generate labels for component props?",
+      default: false,
+    },
   ]);
 }
 
@@ -77,13 +83,18 @@ async function main() {
     componentsDirPath,
     out,
     defineComponent,
+    createLabel,
   } = answers;
 
   const actionConfigs = await readCsvFile(csvPath);
 
   let convertedActions = [];
   for (const actionConfig of actionConfigs) {
-    convertedActions.push(await convertAction(actionConfig, { defineComponent }));
+    const convertedAction = await convertAction(actionConfig, {
+      defineComponent,
+      createLabel
+    });
+    convertedActions.push(convertedAction);
   }
 
   if (outputType === "js") {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -22,8 +22,10 @@ function paramTypeToPropType(type) {
   return mapping[type];
 }
 
-function paramToProp(param, key, required) {
-  const label = param._label ?? `${key.charAt(0).toUpperCase()}${key.slice(1)}`.replace(/_/g, " ");
+function paramToProp(param, key, required, createLabel) {
+  const label = createLabel
+    ? (param._label ?? `${key.charAt(0).toUpperCase()}${key.slice(1)}`.replace(/_/g, " "))
+    : undefined;
   return {
     type: paramTypeToPropType(param.type),
     label,
@@ -32,10 +34,10 @@ function paramToProp(param, key, required) {
   };
 }
 
-function paramsSchemaToProps(params) {
+function paramsSchemaToProps(params, { createLabel }={}) {
   return Object.entries(params.properties).map(([key, value]) => ({
     key,
-    ...paramToProp(value, key, params.required.includes(key)),
+    ...paramToProp(value, key, params.required.includes(key), createLabel),
   }));
 }
 
@@ -76,7 +78,7 @@ async function convert({
   description,
   namespace,
   codeConfig: codeConfigString
-}, { defineComponent=false }={}) {
+}, { defineComponent=false, createLabel=false }={}) {
   // const escapedCodeConfigString = codeConfigString.replace(/\\/g, "\\\\");
   const { params_schema: paramsSchema } = JSON.parse(codeConfigString);
 
@@ -93,7 +95,7 @@ async function convert({
     throw new Error("The legacy action is missing at least 1 auth");
   }
   const appSlug = appProps[0].key;
-  const paramsProps = paramsSchemaToProps(paramsSchema);
+  const paramsProps = paramsSchemaToProps(paramsSchema, { createLabel });
   
   const props = [
     ...appProps,


### PR DESCRIPTION
```sh-session
$ node bin/cli.js ./test/data/actions.csv
? Output as separate javascript files or a single CSV file? JavaScript
? Path to components directory to write files to ./test/output
? Wrap the component with `defineComponent()`? No
? Generate labels for component props? (y/N)
```