### PR TITLE
Remove unused axios from component code

### DIFF
--- a/lib/collections/LegacyAction.js
+++ b/lib/collections/LegacyAction.js
@@ -94,6 +94,17 @@ const traversalMethods = {
       });
   },
 
+  getRequireCalls: function(name) {
+    return this
+      .find(types.CallExpression)
+      .filter((path) => {
+        return path.value.callee?.name === "require";
+      })
+      .filter((path) => {
+        return !name || path.value.arguments?.[0]?.value === name;
+      });
+  },
+
   /**
    * Finds occurrences of `require("@pipedreamhq/platform")`
    * 
@@ -101,12 +112,7 @@ const traversalMethods = {
    */
   getRequirePipedreamHQPlatform: function() {
     return this
-      .find(types.CallExpression)
-      .filter((path) => {
-        const isRequireCall = path.value.callee?.name === "require";
-        const requiresPipedreamHQ = path.value.arguments?.[0]?.value === "@pipedreamhq/platform";
-        return isRequireCall && requiresPipedreamHQ;
-      });
+      .getRequireCalls("@pipedreamhq/platform");
   },
 
   /**

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -11,6 +11,7 @@ const respondToDotRespond = require("./transforms/respond-to-dot-respond");
 const endToFlowExit = require("./transforms/end-to-flow-exit");
 const pipedreamHQtoPipedream = require("./transforms/pipedreamhq-to-pipedream");
 const axiosThisToDollar = require("./transforms/axios-this-to-dollar");
+const removeUnusedAxios = require("./transforms/remove-unused-axios");
 
 function applyTransforms(source, transforms) {
   let output = source;
@@ -32,6 +33,7 @@ function legacyToComponentCode(source) {
     authsToAuth,
     pipedreamHQtoPipedream,
     axiosThisToDollar,
+    removeUnusedAxios,
     programToExpression
   ]);
 }

--- a/lib/transforms/__tests__/transforms.test.js
+++ b/lib/transforms/__tests__/transforms.test.js
@@ -12,6 +12,7 @@ const respondToDotRespond = require("../respond-to-dot-respond");
 const endToFlowExit = require("../end-to-flow-exit");
 const pipedreamhqToPipedream = require("../pipedreamhq-to-pipedream");
 const axiosThisToDollar = require("../axios-this-to-dollar");
+const removeUnusedAxios = require("../remove-unused-axios");
 
 
 describe("params-to-props", () => {
@@ -115,5 +116,18 @@ describe("axios-this-dollar", () => {
     "require(\"@pipedream/platform\").axios(this, { foo: \"bar\" })",
     "require(\"@pipedream/platform\").axios($, { foo: \"bar\" })",
     "transforms `.axios(this, __a)` to `.axios($, __a)`"
+  );
+});
+
+describe("remove-unused-axios", () => {
+  defineInlineTest(removeUnusedAxios, {},
+    "const axios = require(\"axios\")",
+    "",
+    "removes `const axios = require(\"axios\")`"
+  );
+  defineInlineTest(removeUnusedAxios, {},
+    "const foo = require(\"bar\")",
+    "const foo = require(\"bar\")",
+    "doesn't remove `const foo = require(\"bar\")`"
   );
 });

--- a/lib/transforms/remove-unused-axios.js
+++ b/lib/transforms/remove-unused-axios.js
@@ -1,0 +1,23 @@
+const { fromPaths } = require("jscodeshift/dist/Collection");
+const { register } = require("../collections/LegacyAction");
+register();
+
+// remove `const __a = require("axios")` if __a is unused
+
+module.exports = function(fileInfo, api, options) {
+  const j = api.jscodeshift;
+
+  const ast = j(fileInfo.source);
+
+  ast.getRequireCalls("axios")
+    .map((path) => path.parent)
+    .filter((path) => j.VariableDeclarator.check(path.node))
+    .filter((path) => j.Identifier.check(path.value.id))
+    .filter((path) => {
+      const occurrences = fromPaths([path]).getVariableOccurrences(path.value.id.name);
+      return occurrences.length <= 1;
+    })
+    .remove();
+
+  return ast.toSource();
+};

--- a/lib/transforms/testUtils.js
+++ b/lib/transforms/testUtils.js
@@ -6,7 +6,7 @@ function wrapCodeWithFunctionExpr(source) {
   if (source.startsWith("async (")) {
     return source;
   }
-  return `async (params, auths) => {\n${source}\n}`;
+  return `async (params, auths) => {${source && `\n${source}\n`}}`;
 }
 
 // Source: https://bit.ly/3uBzenA


### PR DESCRIPTION
Removes `const axios = require("axios")` in cases where platform axios is used instead.

For example, the following line is removed from the converted action:
https://github.com/js07/pd-convert-actions/blob/d861d215fae024316eb866181b998485989bd73e/examples/add_or_update_subscriber.before.js#L1

Resolves #17 