### PR TITLE
Fix byte character in component description

### DIFF
--- a/lib/fix.js
+++ b/lib/fix.js
@@ -1,5 +1,6 @@
 const { ESLint } = require("eslint");
 const eslintConfig = require("../resources/.eslint.json");
+const { fixByteCharacters } = require("./util");
 
 const eslint = new ESLint({
   baseConfig: eslintConfig,
@@ -16,7 +17,8 @@ async function lintAndFix(source) {
 }
 
 async function fix(source) {
-  return lintAndFix(source);
+  let code = fixByteCharacters(source);
+  return lintAndFix(code);
 }
 
 module.exports = fix;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,10 @@
 const fs = require("fs");
 const path = require("path");
 
+function fixByteCharacters(string) {
+  return string.replace(/[]/g, "'"); // invisible character, supposed to be (’)
+}
+
 function makeFilePath(filePath, relative=false) {
   return relative ? path.join(__dirname, filePath) : filePath;
 }
@@ -21,4 +25,5 @@ function writeFile(filePath, content, { relative = false }={}) {
 module.exports = {
   readFile,
   writeFile,
+  fixByteCharacters
 };


### PR DESCRIPTION
- Replaces `�` with `'` in components

E.g.,
https://github.com/js07/pd-convert-actions/blob/278e7cdadc7e7235c2dcf6b36522780726d8310c/examples/identify.after.js#L14