### PR TITLE
Add legacy_hash_id comment at top of generated file

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -61,6 +61,7 @@ async function convertAction(actionConfig, options) {
     CODE_CONFIG_JSON: codeConfig,
     PUBLISHED_VERSION_MAJOR: versionMajor = 0,
     PUBLISHED_VERSION_MINOR: versionMinor = 0,
+    HID: hashId,
   } = actionConfig;
   try {
     return await convert({
@@ -71,6 +72,7 @@ async function convertAction(actionConfig, options) {
       description,
       versionMajor,
       versionMinor,
+      hashId,
     }, options);
   } catch (error) {
     console.log(`Error converting action "${title}":`, error);

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -85,6 +85,7 @@ async function convert({
   codeConfig: codeConfigString,
   versionMajor,
   versionMinor,
+  hashId,
 }, { defineComponent=false, createLabel=false }={}) {
   // const escapedCodeConfigString = codeConfigString.replace(/\\/g, "\\\\");
   const { params_schema: paramsSchema } = JSON.parse(codeConfigString);
@@ -116,7 +117,8 @@ async function convert({
     name: title,
     description,
     key: componentKey,
-    version: `${versionMajor}.${versionMinor}.0`
+    version: `${versionMajor}.${versionMinor}.0`,
+    hashId,
   }, { defineComponent });
 
   const lintedCode = await fix(componentCode);

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -18,12 +18,12 @@ Handlebars.registerHelper("tostring", function(variable) {
  * @returns {string} The generated component
 */
 function generateComponent(
-  { code, props, name, description, key, version },
+  { code, props, name, description, key, version, hashId },
   { defineComponent } = {}
 ) {
   const templateString = readFile(TEMPLATE_PATH, { relative: true });
   const template = Handlebars.compile(templateString, { noEscape: true });
-  return template({ code, props, name, description, key, version, defineComponent });
+  return template({ code, props, name, description, key, version, defineComponent, hashId });
 }
 
 /**
@@ -32,8 +32,14 @@ function generateComponent(
  * @param {object} opts 
  * @returns {string} The generated component
  */
-function generate({ code, props, name, description, key, version }, { defineComponent } = {}) {
-  return generateComponent({ code, props, name, description, key, version }, { defineComponent });
+function generate(
+  { code, props, name, description, key, version, hashId },
+  { defineComponent } = {}
+) {
+  return generateComponent(
+    { code, props, name, description, key, version, hashId },
+    { defineComponent }
+  );
 }
 
 module.exports = generate;

--- a/resources/templates/action-cjs.handlebars
+++ b/resources/templates/action-cjs.handlebars
@@ -1,3 +1,6 @@
+{{#if (isdefined hashId)}}
+// legacy_hash_id: "{{hashId}}"
+{{/if}}
 {{#if defineComponent}}
 module.exports = defineComponent({
   {{> componentProperties }}


### PR DESCRIPTION
To the top of each component file, adds a comment with the hash ID of the corresponding legacy action.

For example, if the legacy action's hash ID is `a_RAiaRw`, the comment would be:
```js
// legacy_hash_id: "a_RAiaRw"
```

Resolves #21 