### PR TITLE
Set default patch version to 1 for converted actions

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -4,6 +4,7 @@ const fix = require("./fix");
 const parse = require("./parse");
 
 const PLACEHOLDER_APP_SLUG = "app_placeholder";
+const DEFAULT_VERSION_PATCH = 1;
 
 function dbProp() {
   return { key: "db", type: "$.interface.db", isString: true };
@@ -83,8 +84,9 @@ async function convert({
   description,
   namespace,
   codeConfig: codeConfigString,
-  versionMajor,
-  versionMinor,
+  versionMajor = 0,
+  versionMinor = 0,
+  versionPatch = DEFAULT_VERSION_PATCH,
   hashId,
 }, { defineComponent=false, createLabel=false }={}) {
   // const escapedCodeConfigString = codeConfigString.replace(/\\/g, "\\\\");
@@ -117,7 +119,7 @@ async function convert({
     name: title,
     description,
     key: componentKey,
-    version: `${versionMajor}.${versionMinor}.0`,
+    version: `${versionMajor}.${versionMinor}.${versionPatch}`,
     hashId,
   }, { defineComponent });
 


### PR DESCRIPTION
Sets the patch version to 1. E.g., `version: "0.3.1"`.

**Context**
The legacy actions don't have a patch version. The component's major and minor versions match the legacy actions.

Partially overrides #20 