### PR TITLE
Add cjs to esm conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,25 @@ $ node bin/cli.js ./test/data/actions.csv
 ? Output as separate javascript files or a single CSV file? JavaScript
 ? Path to components directory to write files to ./test/output
 ? Wrap the component with `defineComponent()`? No
-? Generate labels for component props? (y/N)
+? Generate labels for component props? No
+? Convert generated component to ESM? (Y/n)
+```
+
+### CLI Options
+```
+USAGE
+  $ bin/cli.js FILE
+
+ARGUMENTS
+  FILE  csv file containing legacy action configs
+
+OPTIONS
+  --outputType=js/csv      Output actions as a csv file or js files
+  --out                    CSV output path
+  --componentsDirPath      Path to components directory to write js files
+  --defineComponent        Wrap the component with defineComponent()
+  --createLabel            Generate labels for component props
+  --[no-]toEsm             Convert generated component to ESM (default: Yes)
 ```
 
 ## Lib
@@ -72,6 +90,7 @@ Fixes
 - Adds declarator for undeclared variables (eslint no-undef)
 - Removes unused variables (eslint no-unused-var)
 - Converts variables to camelCase (eslint camelcase)
+- Converts code from CommonJS to ESModules
 - Fix eslint-fixable eslint errors
 
 # Examples

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -51,7 +51,7 @@ async function prompt() {
       message: "Convert generated component to ESM?",
       default: true,
     },
-  ]);
+  ], argv);
 }
 
 async function readCsvFile(path) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -45,6 +45,12 @@ async function prompt() {
       message: "Generate labels for component props?",
       default: false,
     },
+    {
+      type: "confirm",
+      name: "toEsm",
+      message: "Convert generated component to ESM?",
+      default: true,
+    },
   ]);
 }
 
@@ -88,6 +94,7 @@ async function main() {
     out,
     defineComponent,
     createLabel,
+    toEsm,
   } = answers;
 
   const actionConfigs = await readCsvFile(csvPath);
@@ -96,15 +103,17 @@ async function main() {
   for (const actionConfig of actionConfigs) {
     const convertedAction = await convertAction(actionConfig, {
       defineComponent,
-      createLabel
+      createLabel,
+      toEsm,
     });
     convertedActions.push(convertedAction);
   }
 
   if (outputType === "js") {
+    const ext = toEsm ? "mjs" : "js";
     for (const action of convertedActions) {
       const { code, appSlug, componentSlug } = action;
-      writeFile(`${componentsDirPath}/${appSlug}/actions/${componentSlug}/${componentSlug}.js`, code);
+      writeFile(`${componentsDirPath}/${appSlug}/actions/${componentSlug}/${componentSlug}.${ext}`, code);
     }
   } else {
     const csv = parse(convertedActions, { fields: ["code", "appSlug", "componentSlug"] });

--- a/bin/gen-examples.js
+++ b/bin/gen-examples.js
@@ -26,7 +26,13 @@ async function prompt() {
       message: "Generate labels for component props?",
       default: false,
     },
-  ]);
+    {
+      type: "confirm",
+      name: "toEsm",
+      message: "Convert generated component to ESM?",
+      default: true,
+    },
+  ], argv);
 }
 
 async function readCsvFile(path) {
@@ -67,6 +73,7 @@ async function main() {
     componentsDirPath,
     defineComponent,
     createLabel,
+    toEsm,
   } = answers;
 
   const actionConfigs = await readCsvFile(csvPath);
@@ -74,7 +81,8 @@ async function main() {
   for (const actionConfig of actionConfigs) {
     const convertedAction = await convertAction(actionConfig, {
       defineComponent,
-      createLabel
+      createLabel,
+      toEsm,
     });
 
     const { CODE_RAW: codeRaw, DEFAULT_NAMESPACE: namespace } = actionConfig;

--- a/lib/collections/LegacyAction.js
+++ b/lib/collections/LegacyAction.js
@@ -105,6 +105,14 @@ const traversalMethods = {
       });
   },
 
+  getImports: function(value) {
+    return this
+      .find(types.ImportDeclaration)
+      .filter((path) => {
+        return !value || path.value.source.value === value;
+      });
+  },
+
   /**
    * Finds occurrences of `require("@pipedreamhq/platform")`
    * 

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -70,8 +70,9 @@ function wrapCodeWithFunctionExpr(source) {
 // Get app props from `auths.appName` in code
 // If code has this.$checkpoint, add db prop
 // Convert params to array of props
-// Convert code to component code
-// Generate component file using handlebars template, props, and component code
+// Convert code to component run code
+// Generate component file using handlebars template, props, and component run code
+// Fix issues/eslint errors in generated component file
 /**
  * 
  * @param {object} actionConfig 

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -89,7 +89,7 @@ async function convert({
   versionMinor = 0,
   versionPatch = DEFAULT_VERSION_PATCH,
   hashId,
-}, { defineComponent=false, createLabel=false }={}) {
+}, { defineComponent=false, createLabel=false, toEsm=true }={}) {
   const { params_schema: paramsSchema } = JSON.parse(codeConfigString);
 
   let source = wrapCodeWithFunctionExpr(codeRaw);
@@ -123,7 +123,7 @@ async function convert({
     hashId,
   }, { defineComponent });
 
-  const lintedCode = await fix(componentCode);
+  const lintedCode = await fix(componentCode, { toEsm });
 
   return {
     code: lintedCode,

--- a/lib/fix.js
+++ b/lib/fix.js
@@ -6,6 +6,7 @@ const { applyTransforms } = require("./transforms/testUtils");
 const undefAssignmentToDeclaration = require("./transforms/undef-assignment-to-declaration");
 const removeEmptyObject = require("./transforms/remove-empty-object");
 const snakeToCamelCase = require("./transforms/snake-to-camel-case");
+const cjsToEsm = require("./transforms/cjs-to-esm");
 
 
 const eslint = new ESLint({
@@ -28,7 +29,7 @@ function preFixErrors(source) {
   code = putout(code, {
     plugins: ["remove-unused-variables", "remove-empty-pattern"],
   }).code;
-  return applyTransforms(code, [removeEmptyObject, snakeToCamelCase]);
+  return applyTransforms(code, [removeEmptyObject, snakeToCamelCase, cjsToEsm]);
 }
 
 

--- a/lib/fix.js
+++ b/lib/fix.js
@@ -19,17 +19,26 @@ const eslint = new ESLint({
  * Fix some errors that eslint doesn't autofix before linting.
  *
  * Add variable declarations to undeclared variables before removing unused
- * variables. Remove unused variables before removing empty objects.
+ * variables. Remove unused variables before removing empty objects. Optionally
+ * convert to ESM.
  *
- * @param {string} source 
+ * @param {string} source
+ * @param {object} [options={}]
  * @returns {string}
  */
-function preFixErrors(source) {
-  let code = applyTransforms(source, [undefAssignmentToDeclaration]);
+function preFixErrors(source, { toEsm }={}) {
+  let code = applyTransforms(source, [ undefAssignmentToDeclaration ]);
   code = putout(code, {
-    plugins: ["remove-unused-variables", "remove-empty-pattern"],
+    plugins: [
+      "remove-unused-variables",
+      "remove-empty-pattern"
+    ],
   }).code;
-  return applyTransforms(code, [removeEmptyObject, snakeToCamelCase, cjsToEsm]);
+  return applyTransforms(code, [
+    removeEmptyObject,
+    snakeToCamelCase,
+    ...(toEsm ? [cjsToEsm] : [])
+  ]);
 }
 
 
@@ -40,9 +49,15 @@ async function lintAndFix(source) {
   return output;
 }
 
-async function fix(source) {
+/**
+ * 
+ * @param {string} source 
+ * @param {object} [options={}] 
+ * @returns {string}
+ */
+async function fix(source, { toEsm }={}) {
   let code = fixByteCharacters(source);
-  code = preFixErrors(code);
+  code = preFixErrors(code, { toEsm });
   return lintAndFix(code);
 }
 

--- a/lib/fix.js
+++ b/lib/fix.js
@@ -34,18 +34,24 @@ function preFixErrors(source, { toEsm }={}) {
       "remove-empty-pattern"
     ],
   }).code;
-  return applyTransforms(code, [
+  code = applyTransforms(code, [
     removeEmptyObject,
     snakeToCamelCase,
     ...(toEsm ? [cjsToEsm] : [])
   ]);
+  return code;
 }
 
 
 async function lintAndFix(source) {
   const results = await eslint.lintText(source, { filePath: "components/app_slug/actions/comp_slug/comp_slug.js" });
   const [result] = results;
-  const { output } = result;
+  const { output, messages } = result;
+  for (const message of messages) {
+    if (message.fatal) {
+      console.log("Fatal error linting code:", message);
+    }
+  }
   return output;
 }
 
@@ -58,7 +64,8 @@ async function lintAndFix(source) {
 async function fix(source, { toEsm }={}) {
   let code = fixByteCharacters(source);
   code = preFixErrors(code, { toEsm });
-  return lintAndFix(code);
+  code = await lintAndFix(code);
+  return code;
 }
 
 module.exports = fix;

--- a/lib/transforms/__tests__/transforms.test.js
+++ b/lib/transforms/__tests__/transforms.test.js
@@ -213,4 +213,16 @@ describe("cjs-to-esm", () => {
     "transforms require object declaration to object import declaration",
     false
   );
+  defineInlineTest(cjsToEsm, {},
+    "require(\"foo\").bar();require(\"foo\").bar();",
+    "import { bar } from \"foo\";\nbar();bar();",
+    "transforms require object declaration to object import declaration only once",
+    false
+  );
+  defineInlineTest(cjsToEsm, {},
+    "const foo = require(\"axios\").default;",
+    "import axiosModule from \"axios\";\nconst foo = axiosModule.default;",
+    "transforms `require(\"foo\").default` to `fooModule.default` and `import fooModule from \"foo\"`",
+    false
+  );
 });

--- a/lib/transforms/__tests__/transforms.test.js
+++ b/lib/transforms/__tests__/transforms.test.js
@@ -16,6 +16,7 @@ const removeUnusedAxios = require("../remove-unused-axios");
 const undefAssignmentToDeclaration = require("../undef-assignment-to-declaration");
 const removeEmptyObject = require("../remove-empty-object");
 const snakeToCamelCase = require("../snake-to-camel-case");
+const cjsToEsm = require("../cjs-to-esm");
 
 
 describe("params-to-props", () => {
@@ -139,7 +140,7 @@ describe("undef-assignment-to-declaration", () => {
   defineInlineTest(undefAssignmentToDeclaration, {},
     "  foo = \"bar\";",
     "  let foo = \"bar\";",
-    "converts undefined variable assignment to declaration"
+    "transforms undefined variable assignment to declaration"
   );
   defineInlineTest(undefAssignmentToDeclaration, {}, `
   foo = "bar";
@@ -184,5 +185,32 @@ describe("snake-to-camel-case", () => {
     "const obj = { foo_bar: 5 };",
     "const obj = { foo_bar: 5 };",
     "doesn't converts snake case property to camelCase"
+  );
+});
+
+describe("cjs-to-esm", () => {
+  defineInlineTest(cjsToEsm, {},
+    "module.exports = {};",
+    "export default {};",
+    "transforms `module.exports =` to `export default`",
+    false,
+  );
+  defineInlineTest(cjsToEsm, {},
+    "require(\"foo\").bar();",
+    "import { bar } from \"foo\";\nbar();",
+    "transforms require with member call expression to import and call expression",
+    false
+  );
+  defineInlineTest(cjsToEsm, {},
+    "const bar = require(\"foo\");",
+    "import bar from \"foo\";",
+    "transforms require variable declaration to default import declaration",
+    false
+  );
+  defineInlineTest(cjsToEsm, {},
+    "const { bar } = require(\"foo\");",
+    "import { bar } from \"foo\";",
+    "transforms require object declaration to object import declaration",
+    false
   );
 });

--- a/lib/transforms/cjs-to-esm.js
+++ b/lib/transforms/cjs-to-esm.js
@@ -1,7 +1,7 @@
 const { register } = require("../collections/LegacyAction");
 register();
 
-// Convert `module.exports =` to `export default {`
+// Convert `module.exports =` to `export default`
 // Convert `__b = require("__a")` to `import __b from "__a"`
 // Convert `{ __b } = require("__a")` to `import { __b } from "__a"` at top level
 // Convert `require("__a").__c` to `__c` and `import { __c } from "__a"` at top level
@@ -27,7 +27,7 @@ module.exports = function(fileInfo, api, options) {
   const firstNode = getFirstNode();
   const { comments } = firstNode;
 
-  // Convert `module.exports =` to `export default {`
+  // Convert `module.exports =` to `export default`
   ast.find(j.AssignmentExpression)
     .filter((path) => {
       return j.MemberExpression.check(path.value.left)

--- a/lib/transforms/cjs-to-esm.js
+++ b/lib/transforms/cjs-to-esm.js
@@ -1,0 +1,104 @@
+const { register } = require("../collections/LegacyAction");
+register();
+
+// Convert `module.exports =` to `export default {`
+// Convert `__b = require("__a")` to `import __b from "__a"`
+// Convert `{ __b } = require("__a")` to `import { __b } from "__a"` at top level
+// Convert `require("__a").__c` to `__c` and `import { __c } from "__a"` at top level
+
+module.exports = function(fileInfo, api, options) {
+  const j = api.jscodeshift;
+  const ast = j(fileInfo.source);
+
+  const getFirstPath = () => ast.find(j.Program).get("body", 0);
+  const getFirstNode = () => getFirstPath().node;
+
+  const prependImport = (propNames, sourceValue) => {
+    getFirstPath().insertBefore(
+      j.importDeclaration(
+        Array.isArray(propNames)
+          ? propNames.map((p) => j.importSpecifier(j.identifier(p)))
+          : [j.importDefaultSpecifier(j.identifier(propNames))],
+        j.literal(sourceValue)
+      )
+    );
+  };
+  // Save the comments attached to the first node
+  const firstNode = getFirstNode();
+  const { comments } = firstNode;
+
+  // Convert `module.exports =` to `export default {`
+  ast.find(j.AssignmentExpression)
+    .filter((path) => {
+      return j.MemberExpression.check(path.value.left)
+        && j.Identifier.check(path.value.left.object)
+        && j.Identifier.check(path.value.left.property)
+        && path.value.left.object.name === "module"
+        && path.value.left.property.name === "exports";
+    })
+    .forEach((path) => {
+      path.parent.replace(j.exportDefaultDeclaration(path.value.right));
+    });
+
+  // Convert `require("__a").__c` to `__c` and `import { __c } from "__a"` at top level
+  ast.getRequireCalls()
+    .filter((path) => {
+      const node = path.value;
+      return j.MemberExpression.check(path.parent.value)
+        && path.parent.value.object === node
+        && j.Identifier.check(path.parent.value.property);
+    })
+    .forEach((path) => {
+      const fnName = path.parent.value.property.name;
+      const sourceValue = path.get("arguments", 0).value.value; 
+      prependImport([fnName], sourceValue);
+      path.parent.replace(j.identifier(fnName));
+    });
+
+  // Convert `{ __b } = require("__a")` to `import { __b } from "__a"` at top level
+  ast.getRequireCalls()
+    .filter((path) => {
+      const node = path.value;
+      return j.VariableDeclarator.check(path.parent.value)
+      && path.parent.value.init === node
+      && j.ObjectPattern.check(path.parent.value.id);
+    })
+    .forEach((path) => {
+      const fnNames = path.parent.value.id.properties.map(p => p.key?.name);
+      const sourceValue = path.get("arguments", 0).value.value; 
+      prependImport(fnNames, sourceValue);
+      path.parent.prune();
+    });
+
+  // Convert `__b = require("__a")` to `import __b from "__a"`
+  ast.getRequireCalls()
+    .filter((path) => {
+      const node = path.value;
+      return j.VariableDeclarator.check(path.parent.value)
+      && path.parent.value.init === node
+      && j.Identifier.check(path.parent.value.id);
+    })
+    .forEach((path) => {
+      const fnName = path.parent.value.id.name;
+      const sourceValue = path.get("arguments", 0).value.value; 
+      prependImport(fnName, sourceValue);
+      path.parent.prune();
+    });
+
+  // If the first node has been modified or deleted, reattach the comments
+  const firstNode2 = getFirstNode();
+  if (firstNode2 !== firstNode) {
+    if (comments) {
+      firstNode.comments = [];
+      ast.find(j.Program).get("comments").replace(comments);
+    }
+
+    // Add newline after last import declaration
+    const lastImport = ast.find(j.ImportDeclaration).at(-1);
+    if (lastImport) {
+      lastImport.insertAfter();
+    }
+  }
+
+  return ast.toSource();
+};

--- a/lib/transforms/cjs-to-esm.js
+++ b/lib/transforms/cjs-to-esm.js
@@ -1,4 +1,6 @@
 const { register } = require("../collections/LegacyAction");
+const { identifier } = require("safe-identifier");
+const camelcase = require("camelcase");
 register();
 
 // Convert `module.exports =` to `export default`
@@ -13,12 +15,41 @@ module.exports = function(fileInfo, api, options) {
   const getFirstPath = () => ast.find(j.Program).get("body", 0);
   const getFirstNode = () => getFirstPath().node;
 
-  const prependImport = (propNames, sourceValue) => {
+  const hasImport = (propName, sourceValue) => {
+    return ast
+      .find(j.ImportDeclaration)
+      .filter((path) => {
+        return path.value.source.value === sourceValue
+          && path.value.specifiers.find((s) => {
+            return s.local
+              ? s.local.name === propName
+              : s.imported.name === propName;
+          });
+      })
+      .size() > 0;
+  };
+
+
+  const prependDefaultImport = (propName, sourceValue) => {
+    if (hasImport(propName, sourceValue)) {
+      return;
+    }
     getFirstPath().insertBefore(
       j.importDeclaration(
-        Array.isArray(propNames)
-          ? propNames.map((p) => j.importSpecifier(j.identifier(p)))
-          : [j.importDefaultSpecifier(j.identifier(propNames))],
+        [j.importDefaultSpecifier(j.identifier(propName))],
+        j.literal(sourceValue)
+      )
+    );
+  };
+
+  const prependImport = (propNames, sourceValue) => {
+    const newPropNames = propNames.filter((p) => !hasImport(p, sourceValue));
+    if (newPropNames.length === 0) {
+      return;
+    }
+    getFirstPath().insertBefore(
+      j.importDeclaration(
+        propNames.map((p) => j.importSpecifier(j.identifier(p))),
         j.literal(sourceValue)
       )
     );
@@ -49,8 +80,23 @@ module.exports = function(fileInfo, api, options) {
         && j.Identifier.check(path.parent.value.property);
     })
     .forEach((path) => {
-      const fnName = path.parent.value.property.name;
-      const sourceValue = path.get("arguments", 0).value.value; 
+      const sourceValue = path.get("arguments", 0).value.value;
+      let fnName = path.parent.value.property.name;
+      // Hack? Convert `require("__a").default` to `__aModule.default` and
+      // `import __aModule from "__a"` instead
+      if (fnName === "default") {
+        const moduleName = camelcase(identifier(`${sourceValue}Module`));
+        prependDefaultImport(moduleName, sourceValue);
+        path.replace(j.identifier(moduleName));
+        return;
+      }
+      // Hack to fix duplicate axios var when axios and pipedream axios are used
+      if (
+        fnName === "axios" && sourceValue !== "axios"
+        && (ast.getRequireCalls("axios").size() > 0 || ast.getImports("axios").size() > 0)
+      ) {
+        fnName = "pipedreamAxios"; 
+      }
       prependImport([fnName], sourceValue);
       path.parent.replace(j.identifier(fnName));
     });
@@ -81,7 +127,7 @@ module.exports = function(fileInfo, api, options) {
     .forEach((path) => {
       const fnName = path.parent.value.id.name;
       const sourceValue = path.get("arguments", 0).value.value; 
-      prependImport(fnName, sourceValue);
+      prependDefaultImport(fnName, sourceValue);
       path.parent.prune();
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7699,6 +7699,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "safe-identifier": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
+      "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w=="
+    },
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "json2csv": "^5.0.6",
     "lodash.once": "^4.1.1",
     "minimist": "^1.2.5",
-    "putout": "^12.12.0"
+    "putout": "^12.12.0",
+    "safe-identifier": "^0.4.2"
   },
   "devDependencies": {
     "jest": "^27.5.1"


### PR DESCRIPTION
Converts `module.exports` to `export default` and `require` to `import`.

* `module.exports =` -> `export default`
* `__b = require("__a")` -> `import __b from "__a"`
* `{ __b } = require("__a")` -> `import { __b } from "__a"` at top level
* `require("__a").default` -> `__aModule.default` and `import __aModule from "__a"` at top level
* `require("__a").__c` -> `__c` and `import { __c } from "__a"` at top level

Todo
- Add CLI option for converting to ESM

Resolves #1