### PR TITLE
Add option to disable props-description eslint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ $ node bin/cli.js ./test/data/actions.csv
 ? Path to components directory to write files to ./test/output
 ? Wrap the component with `defineComponent()`? No
 ? Generate labels for component props? No
+? eslint-disable props-description rule when missing a prop description? No
 ? Convert generated component to ESM? (Y/n)
 ```
 
@@ -30,12 +31,13 @@ ARGUMENTS
   FILE  csv file containing legacy action configs
 
 OPTIONS
-  --outputType=js/csv      Output actions as a csv file or js files
-  --out                    CSV output path
-  --componentsDirPath      Path to components directory to write js files
-  --defineComponent        Wrap the component with defineComponent()
-  --createLabel            Generate labels for component props
-  --[no-]toEsm             Convert generated component to ESM (default: Yes)
+  --outputType=js/csv             Output actions as a csv file or js files
+  --out                           CSV output path
+  --componentsDirPath             Path to components directory to write js files
+  --defineComponent               Wrap the component with defineComponent()
+  --createLabel                   Generate labels for component props
+  --eslintDisablePropsDescription Disable props-description rule when missing a prop description
+  --[no-]toEsm                    Convert generated component to ESM (default: Yes)
 ```
 
 ## Lib

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -47,6 +47,12 @@ async function prompt() {
     },
     {
       type: "confirm",
+      name: "eslintDisablePropsDescription",
+      message: "eslint-disable props-description rule when missing a prop description?",
+      default: false,
+    },
+    {
+      type: "confirm",
       name: "toEsm",
       message: "Convert generated component to ESM?",
       default: true,
@@ -95,6 +101,7 @@ async function main() {
     defineComponent,
     createLabel,
     toEsm,
+    eslintDisablePropsDescription,
   } = answers;
 
   const actionConfigs = await readCsvFile(csvPath);
@@ -105,6 +112,7 @@ async function main() {
       defineComponent,
       createLabel,
       toEsm,
+      eslintDisablePropsDescription,
     });
     convertedActions.push(convertedAction);
   }

--- a/bin/gen-examples.js
+++ b/bin/gen-examples.js
@@ -28,6 +28,12 @@ async function prompt() {
     },
     {
       type: "confirm",
+      name: "eslintDisablePropsDescription",
+      message: "eslint-disable props-description rule when missing a prop description?",
+      default: false,
+    },
+    {
+      type: "confirm",
       name: "toEsm",
       message: "Convert generated component to ESM?",
       default: true,
@@ -74,6 +80,7 @@ async function main() {
     defineComponent,
     createLabel,
     toEsm,
+    eslintDisablePropsDescription,
   } = answers;
 
   const actionConfigs = await readCsvFile(csvPath);
@@ -83,6 +90,7 @@ async function main() {
       defineComponent,
       createLabel,
       toEsm,
+      eslintDisablePropsDescription,
     });
 
     const { CODE_RAW: codeRaw } = actionConfig;

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -95,7 +95,12 @@ async function convert({
   versionMinor = 0,
   versionPatch = DEFAULT_VERSION_PATCH,
   hashId,
-}, { defineComponent=false, createLabel=false, toEsm=true }={}) {
+}, {
+  defineComponent=false,
+  createLabel=false,
+  toEsm=true,
+  eslintDisablePropsDescription = false,
+}={}) {
   const { params_schema: paramsSchema } = JSON.parse(codeConfigString);
 
   let source = wrapCodeWithFunctionExpr(codeRaw);
@@ -120,6 +125,9 @@ async function convert({
   
   const componentSlug = makeComponentSlug(appSlug, namespace);
   const componentKey = makeComponentKey(appSlug, componentSlug);
+
+  const hasPropWithoutDescription = props.find((p) => p.description === undefined);
+
   const componentCode = generate({
     code: transformedCode,
     props,
@@ -128,7 +136,10 @@ async function convert({
     key: componentKey,
     version: `${versionMajor}.${versionMinor}.${versionPatch}`,
     hashId,
-  }, { defineComponent });
+  }, {
+    defineComponent,
+    eslintDisablePropsDescription: eslintDisablePropsDescription && hasPropWithoutDescription
+  });
 
   const lintedCode = await fix(componentCode, { toEsm });
 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -19,11 +19,21 @@ Handlebars.registerHelper("tostring", function(variable) {
 */
 function generateComponent(
   { code, props, name, description, key, version, hashId },
-  { defineComponent } = {}
+  { defineComponent, eslintDisablePropsDescription, } = {}
 ) {
   const templateString = readFile(TEMPLATE_PATH, { relative: true });
   const template = Handlebars.compile(templateString, { noEscape: true });
-  return template({ code, props, name, description, key, version, defineComponent, hashId });
+  return template({ 
+    code,
+    props, 
+    name,
+    description,
+    key,
+    version,
+    defineComponent,
+    hashId,
+    eslintDisablePropsDescription 
+  });
 }
 
 /**
@@ -34,11 +44,11 @@ function generateComponent(
  */
 function generate(
   { code, props, name, description, key, version, hashId },
-  { defineComponent } = {}
+  { defineComponent, eslintDisablePropsDescription } = {}
 ) {
   return generateComponent(
     { code, props, name, description, key, version, hashId },
-    { defineComponent }
+    { defineComponent, eslintDisablePropsDescription },
   );
 }
 

--- a/resources/templates/action-cjs.handlebars
+++ b/resources/templates/action-cjs.handlebars
@@ -17,6 +17,9 @@ module.exports = {
   description: {{tostring description}},
   version: {{tostring version}},
   type: "action",
+{{#if eslintDisablePropsDescription}}
+  /* eslint-disable pipedream/props-description */
+{{/if}}
   props: {
   {{#each props}}
     {{> componentProp }}


### PR DESCRIPTION
- Optionally adds an eslint-disable comment when a component prop is missing a description
- Updates README with `eslintDisablePropsDescription` CLI option

For example, when `eslintDisablePropsDescription` is `true`, the generated `chat_api_for_whatsapp-send-message.mjs` includes the following:
```js
  /* eslint-disable pipedream/props-description */
  props: {
    chat_api_for_whatsapp: {
      type: "app",
      app: "chat_api_for_whatsapp",
    },
    phone: {
      type: "string",
    },
    body: {
      type: "string",
    },
```

Addresses part of #30