### PR TITLE
Add param-enum to prop-options conversion

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -38,7 +38,8 @@ function paramToProp(param, paramKey, required, createLabel) {
     type: paramTypeToPropType(param.type),
     label,
     description: param.description?.trim(),
-    optional: !required || undefined
+    optional: !required || undefined,
+    options: param.enum,
   };
 }
 

--- a/resources/templates/action-cjs.handlebars
+++ b/resources/templates/action-cjs.handlebars
@@ -45,6 +45,13 @@ module.exports = {
     {{#if (isdefined this.optional)}}
       optional: {{this.optional}},
     {{/if}}
+    {{#if (isdefined this.options)}}
+      options: [
+      {{#each this.options}}
+        {{tostring this}},
+      {{/each}}
+      ],
+    {{/if}}
     },
   {{/if}}
 {{/inline}}


### PR DESCRIPTION
For example, if the param config is:
```json
  "sort_type": {
    "type": "string",
    "description": "Sort by a specific attribute",
    "example": "created_utc",
    "enum": ["score", "num_comments", "created_utc"]
  }
```
then the generated prop is:
```js
    "sort_type": {
      type: "string",
      description: "Sort by a specific attribute",
      optional: true,
      options: [
        "score",
        "num_comments",
        "created_utc",
      ],
    },
```

Resolves #35