### PR TITLE
Fix CJS to ESM conversion missing some require calls

### DIFF
--- a/lib/transforms/__tests__/transforms.test.js
+++ b/lib/transforms/__tests__/transforms.test.js
@@ -225,4 +225,10 @@ describe("cjs-to-esm", () => {
     "transforms `require(\"foo\").default` to `fooModule.default` and `import fooModule from \"foo\"`",
     false
   );
+  defineInlineTest(cjsToEsm, {},
+    "require(\"foo-bar\")(5);",
+    "import fooBar from \"foo-bar\";\nfooBar(5);",
+    "transforms `require(\"foo-bar\")(5)` to `fooBar(5)` and `import fooBar from \"foo-bar\"`",
+    false
+  );
 });

--- a/lib/transforms/cjs-to-esm.js
+++ b/lib/transforms/cjs-to-esm.js
@@ -7,6 +7,8 @@ register();
 // Convert `__b = require("__a")` to `import __b from "__a"`
 // Convert `{ __b } = require("__a")` to `import { __b } from "__a"` at top level
 // Convert `require("__a").__c` to `__c` and `import { __c } from "__a"` at top level
+// Convert `require("__a")(__b)` to `camelCase(__a)(__b)` and 
+//  `import camelCase(__a) from "__a" at top level
 
 module.exports = function(fileInfo, api, options) {
   const j = api.jscodeshift;
@@ -129,6 +131,17 @@ module.exports = function(fileInfo, api, options) {
       const sourceValue = path.get("arguments", 0).value.value; 
       prependDefaultImport(fnName, sourceValue);
       path.parent.prune();
+    });
+
+  // ELSE, for all other `require()` call expressions
+  // Convert `require("__a")(__b)` to `camelCase(__a)(__b)` and 
+  //  `import camelCase(__a) from "__a" at top level
+  ast.getRequireCalls()
+    .forEach((path) => {
+      const sourceValue = path.get("arguments", 0).value.value;
+      const fnName = camelcase(sourceValue);
+      prependDefaultImport(fnName, sourceValue);
+      path.replace(j.identifier(fnName));
     });
 
   // If the first node has been modified or deleted, reattach the comments


### PR DESCRIPTION
Adds conversion:
```js
require("foo-bar")(arg);
```
->
```js
import fooBar from "foo-bar";
fooBar(arg);
```

**Context**
Previously, `require("foo")(bar)` was not converted, causing an error when attempting to publish the action.