### PR TITLE
Add prop labels to generated components from param _label

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ node bin/cli.js ./test/data/actions.csv
 ? Output as separate javascript files or a single CSV file? JavaScript
 ? Path to components directory to write files to ./test/output
 ? Wrap the component with `defineComponent()`? No
-? Generate labels for component props? No
+? Generate labels for component props without labels? No
 ? Convert generated component to ESM? (Y/n)
 ```
 
@@ -34,7 +34,7 @@ OPTIONS
   --out                    CSV output path
   --componentsDirPath      Path to components directory to write js files
   --defineComponent        Wrap the component with defineComponent()
-  --createLabel            Generate labels for component props
+  --createLabel            Generate labels for component props without labels
   --[no-]toEsm             Convert generated component to ESM (default: Yes)
 ```
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -42,7 +42,7 @@ async function prompt() {
     {
       type: "confirm",
       name: "createLabel",
-      message: "Generate labels for component props?",
+      message: "Generate labels for component props without labels?", // (param._label)
       default: false,
     },
     {

--- a/bin/gen-examples.js
+++ b/bin/gen-examples.js
@@ -23,7 +23,7 @@ async function prompt() {
     {
       type: "confirm",
       name: "createLabel",
-      message: "Generate labels for component props?",
+      message: "Generate labels for component props without labels?",
       default: false,
     },
     {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -27,9 +27,10 @@ function paramTypeToPropType(type) {
 }
 
 function paramToProp(param, paramKey, required, createLabel) {
-  const label = createLabel
-    ? (param._label ?? `${key.charAt(0).toUpperCase()}${key.slice(1)}`.replace(/_/g, " "))
-    : undefined;
+  const label = param._label || 
+    (createLabel
+      ? `${key.charAt(0).toUpperCase()}${key.slice(1)}`.replace(/_/g, " ")
+      : undefined);
   // If a prop key contains a colon, its object key must be a string literal
   // rather than identifier (e.g. `{ prop:key: {} }` -> `{ "prop:key": {} }`)
   const key = paramKey.includes(":") ? `"${paramKey}"` : paramKey;


### PR DESCRIPTION
Adds a `label` property to generated component props if corresponding param had a `_label`.

For example:
- params_schema
```json
{
  "params_schema": {
    "type": "object",
    "properties": {
      "bucket": {
        "type": "string",
        "_label": "S3 Bucket Name"
      },
      "ContentType": {
        "type": "string",
        "_label": "Content Type",
        "description": "MIME type of the content to upload, for S3 metadata"
      },
      "filename": {
        "type": "string",
        "_label": "Filename",
        "description": "Filename with extension",
        "example": "test.html"
      },
      "data": {
        "type": "string",
        "_label": "Base64-encoded Data",
        "description": "A string of base64-encoded data, or a variable reference to that string"
      }
    },
    "required": ["bucket", "ContentType", "filename", "data"]
  },
  "this_shape": { "S3Response": {} }
}
```
- props
```js
  props: {
    aws: {
      type: "app",
      app: "aws",
    },
    bucket: {
      type: "string",
      label: "S3 Bucket Name",
    },
    ContentType: {
      type: "string",
      label: "Content Type",
      description: "MIME type of the content to upload, for S3 metadata",
    },
    filename: {
      type: "string",
      label: "Filename",
      description: "Filename with extension",
    },
    data: {
      type: "string",
      label: "Base64-encoded Data",
      description: "A string of base64-encoded data, or a variable reference to that string",
    },
  },
```