### PR TITLE
Add appPlaceholder option for convert lib and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ OPTIONS
   --defineComponent        Wrap the component with defineComponent()
   --createLabel            Generate labels for component props without labels
   --[no-]toEsm             Convert generated component to ESM (default: Yes)
+  --appPlaceholder         App name slug to use if legacy code is authless
 ```
 
 ## Lib

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -95,6 +95,7 @@ async function main() {
     defineComponent,
     createLabel,
     toEsm,
+    appPlaceholder,
   } = answers;
 
   const actionConfigs = await readCsvFile(csvPath);
@@ -105,6 +106,7 @@ async function main() {
       defineComponent,
       createLabel,
       toEsm,
+      appPlaceholder,
     });
     convertedActions.push(convertedAction);
   }

--- a/bin/gen-examples.js
+++ b/bin/gen-examples.js
@@ -74,6 +74,7 @@ async function main() {
     defineComponent,
     createLabel,
     toEsm,
+    appPlaceholder,
   } = answers;
 
   const actionConfigs = await readCsvFile(csvPath);
@@ -83,6 +84,7 @@ async function main() {
       defineComponent,
       createLabel,
       toEsm,
+      appPlaceholder,
     });
 
     const { CODE_RAW: codeRaw } = actionConfig;

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -4,7 +4,7 @@ const fix = require("./fix");
 const parse = require("./parse");
 const { paramCase } = require("param-case");
 
-const PLACEHOLDER_APP_SLUG = "app_placeholder";
+const DEFAULT_PLACEHOLDER_APP_SLUG = "app_placeholder";
 const DEFAULT_VERSION_PATCH = 1;
 
 function dbProp() {
@@ -99,7 +99,12 @@ async function convert({
   versionMinor = 0,
   versionPatch = DEFAULT_VERSION_PATCH,
   hashId,
-}, { defineComponent=false, createLabel=false, toEsm=true }={}) {
+}, {
+  defineComponent=false,
+  createLabel=false,
+  toEsm=true,
+  appPlaceholder=DEFAULT_PLACEHOLDER_APP_SLUG,
+}={}) {
   const { params_schema: paramsSchema } = JSON.parse(codeConfigString);
 
   let source = wrapCodeWithFunctionExpr(codeRaw);
@@ -111,7 +116,7 @@ async function convert({
 
   // Get props from code (`auths.app`) & params
   const appProps = authsToAppProps(auths);
-  const appSlug = appProps?.[0]?.key ?? PLACEHOLDER_APP_SLUG;
+  const appSlug = appProps?.[0]?.key ?? appPlaceholder;
   const paramsProps = paramsSchemaToProps(paramsSchema, { createLabel });
   
   const props = [


### PR DESCRIPTION
`appPlaceholder` is used as the app name if the converted legacy code is missing an `auths.<app_name>`.