### PR TITLE
Add addPlaceholderAppProp conversion option to CLI and lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ OPTIONS
   --createLabel            Generate labels for component props without labels
   --[no-]toEsm             Convert generated component to ESM (default: Yes)
   --appPlaceholder         App name slug to use if legacy code is authless
+  --addPlaceholderAppProp  Add an appPlaceholder app prop if no apps are found
 ```
 
 ## Lib

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -96,6 +96,7 @@ async function main() {
     createLabel,
     toEsm,
     appPlaceholder,
+    addPlaceholderAppProp,
   } = answers;
 
   const actionConfigs = await readCsvFile(csvPath);
@@ -107,6 +108,7 @@ async function main() {
       createLabel,
       toEsm,
       appPlaceholder,
+      addPlaceholderAppProp,
     });
     convertedActions.push(convertedAction);
   }

--- a/bin/gen-examples.js
+++ b/bin/gen-examples.js
@@ -75,6 +75,7 @@ async function main() {
     createLabel,
     toEsm,
     appPlaceholder,
+    addPlaceholderAppProp,
   } = answers;
 
   const actionConfigs = await readCsvFile(csvPath);
@@ -85,6 +86,7 @@ async function main() {
       createLabel,
       toEsm,
       appPlaceholder,
+      addPlaceholderAppProp,
     });
 
     const { CODE_RAW: codeRaw } = actionConfig;

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -104,6 +104,7 @@ async function convert({
   createLabel=false,
   toEsm=true,
   appPlaceholder=DEFAULT_PLACEHOLDER_APP_SLUG,
+  addPlaceholderAppProp=false,
 }={}) {
   const { params_schema: paramsSchema } = JSON.parse(codeConfigString);
 
@@ -115,7 +116,10 @@ async function convert({
   } = parse(source);
 
   // Get props from code (`auths.app`) & params
-  const appProps = authsToAppProps(auths);
+  const appNames = (auths.length === 0 & addPlaceholderAppProp)
+    ? [appPlaceholder]
+    : auths;
+  const appProps = authsToAppProps(appNames);
   const appSlug = appProps?.[0]?.key ?? appPlaceholder;
   const paramsProps = paramsSchemaToProps(paramsSchema, { createLabel });
   


### PR DESCRIPTION
* The option adds a "placeholder" app prop to a generated action's props if the legacy action doesn't use `auths`
* The app prop's name is determined by the `appPlaceholder` option, or "app_placeholder" by default

For example:
```
./bin/cli.js test/data/actions.csv --appPlaceholder pipedream --addPlaceholderAppProp
```

```js
  // ...
  props: {
    pipedream: {
      type: "app",
      app: "pipedream",
    },
```