### PR TITLE
#42 Fix conversion of reused named export

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Code
 - `$send` -> `$.send`
 - `$respond` -> `$.respond`
 - `$end` -> `$.flow.exit`
-- `this.name = "value"` -> `$.export("name", "value")`
+- `this.name = "value"` -> `let name; try { name = "value" } finally { $.export("name", name) }`
 - `params` -> `this`
 - `auths.app_name` -> `this.app_name.$auth` (+ `app_name` prop)
 - `require("@pipedreamhq/platform")` -> `require("@pipedream/platform")`

--- a/lib/transforms/__tests__/transforms.test.js
+++ b/lib/transforms/__tests__/transforms.test.js
@@ -21,6 +21,8 @@ import undefAssignmentToDeclaration from "../undef-assignment-to-declaration.js"
 import removeEmptyObject from "../remove-empty-object.js";
 import snakeToCamelCase from "../snake-to-camel-case.js";
 import cjsToEsm from "../cjs-to-esm.js";
+// To mock ESM modules using Jest, need to use dynamic import() after jest.mock
+// calls to load the mocked modules
 const namedExportToDollarExport = await import("../named-export-to-dollar-export.js");
 
 describe("params-to-props", () => {
@@ -50,7 +52,8 @@ describe("auths-to-auth", () => {
 });
 
 describe("named-to-dollar-export", () => {
-  defineInlineTest(namedExportToDollarExport, {}, // $.export is done in finally clause of try/finally
+  // $.export is done in finally clause of try/finally
+  defineInlineTest(namedExportToDollarExport, {},
     "this.foo = \"bar\";", 
     `
       let foo;

--- a/lib/transforms/__tests__/transforms.test.js
+++ b/lib/transforms/__tests__/transforms.test.js
@@ -61,26 +61,43 @@ describe("named-to-dollar-export", () => {
         $.export("foo", foo);
       }
     `,
-    "transforms `this.__a = __b` to `let __a = __b`",
+    "transforms `this.__a = __b` to `let __a; try { __a = __b } finally { $.export(\"__a\", __a) }`",
     { formatCode: true }
   );
 
-  // TODO fix these tests
-  // defineInlineTest(namedExportToDollarExport, {}, `
-  //   this.foo = "bar";
-  //   const foo = "asdf"`, `
-  //   let foo_${mockUniqueId} = "bar";
-  //   const foo = "asdf"`,
-  // "transforms `this.__a = __b; const __a` to `let __a_uniqueId = __b; const __a`"
-  // );
+  defineInlineTest(namedExportToDollarExport, {}, `
+    this.foo = "bar";
+    const foo = "asdf"`,
+  `
+    let foo_${mockUniqueId};
 
-  // defineInlineTest(namedExportToDollarExport, {}, `
-  // this.foo = [];
-  // this.food.push(123);`, `
-  // let foo = [];
-  // foo.push(123);`,
-  // "transforms `this.__a = []; this.__a.push(123)` to `let __a = []; __a.push(123)`"
-  // );
+    try {
+      foo_${mockUniqueId} = "bar";
+      const foo = "asdf"
+    } finally {
+      $.export("foo", foo_${mockUniqueId});
+    }
+  `,
+  "transforms `this.__a = __b; const __a;` to `let __a_uniqueId; try { __a_uniqueId = __b; const __a; } finally { $.export(\"__a\", __a_uniqueId) }`",
+  { formatCode: true }
+  );
+
+  defineInlineTest(namedExportToDollarExport, {}, `
+    this.foo = [];
+    this.foo.push(123);`,
+  `
+    let foo;
+
+    try {
+      foo = [];
+      foo.push(123);
+    } finally {
+      $.export("foo", foo);
+    }
+  `,
+  "transforms `this.__a = []; this.__a.push(123)` to `let __a; try { __a = []; __a.push(123); } finally { $.export(\"__a\", __a) }`",
+  { formatCode: true }
+  );
 });
 
 describe("program-to-expression", () => {

--- a/lib/transforms/__tests__/transforms.test.js
+++ b/lib/transforms/__tests__/transforms.test.js
@@ -50,17 +50,19 @@ describe("auths-to-auth", () => {
 });
 
 describe("named-to-dollar-export", () => {
-  // TODO Allow any whitespacing in defineInlineTest input and output
   defineInlineTest(namedExportToDollarExport, {}, // $.export is done in finally clause of try/finally
-    "this.foo = \"bar\";",
-    `  let foo;
+    "this.foo = \"bar\";", 
+    `
+      let foo;
 
-  try {
-  foo = "bar";
-  } finally {
-    $.export("foo", foo);
-  }`,
-    "transforms `this.__a = __b` to `let __a = __b`"
+      try {
+        foo = "bar";
+      } finally {
+        $.export("foo", foo);
+      }
+    `,
+    "transforms `this.__a = __b` to `let __a = __b`",
+    { formatCode: true }
   );
 
   // TODO fix these tests
@@ -86,7 +88,7 @@ describe("program-to-expression", () => {
     "async (params, auths) => { const foo = \"bar\"; }",
     "{ const foo = \"bar\"; }",
     "transforms program to an expression",
-    false,
+    { wrapCode: false },
   );
 });
 
@@ -189,7 +191,7 @@ describe("remove-empty-object", () => {
     "return { async run({}) {} };",
     "return { async run() {} };",
     "removes empty object function parameter from function expression",
-    false,
+    { wrapCode: false },
   );
   defineInlineTest(removeEmptyObject, {},
     "function run({ foo }) {}",
@@ -221,42 +223,42 @@ describe("cjs-to-esm", () => {
     "export default {};",
     "export default {};",
     "transforms `module.exports =` to `export default`",
-    false,
+    { wrapCode: false },
   );
   defineInlineTest(cjsToEsm, {},
     "require(\"foo\").bar();",
     "import { bar } from \"foo\";\nbar();",
     "transforms require with member call expression to import and call expression",
-    false
+    { wrapCode: false }
   );
   defineInlineTest(cjsToEsm, {},
     "const bar = require(\"foo\");",
     "import bar from \"foo\";",
     "transforms require variable declaration to default import declaration",
-    false
+    { wrapCode: false }
   );
   defineInlineTest(cjsToEsm, {},
     "const { bar } = require(\"foo\");",
     "import { bar } from \"foo\";",
     "transforms require object declaration to object import declaration",
-    false
+    { wrapCode: false }
   );
   defineInlineTest(cjsToEsm, {},
     "require(\"foo\").bar();require(\"foo\").bar();",
     "import { bar } from \"foo\";\nbar();bar();",
     "transforms require object declaration to object import declaration only once",
-    false
+    { wrapCode: false }
   );
   defineInlineTest(cjsToEsm, {},
     "const foo = require(\"axios\").default;",
     "import axiosModule from \"axios\";\nconst foo = axiosModule.default;",
     "transforms `require(\"foo\").default` to `fooModule.default` and `import fooModule from \"foo\"`",
-    false
+    { wrapCode: false }
   );
   defineInlineTest(cjsToEsm, {},
     "require(\"foo-bar\")(5);",
     "import fooBar from \"foo-bar\";\nfooBar(5);",
     "transforms `require(\"foo-bar\")(5)` to `fooBar(5)` and `import fooBar from \"foo-bar\"`",
-    false
+    { wrapCode: false }
   );
 });

--- a/lib/transforms/__tests__/transforms.test.js
+++ b/lib/transforms/__tests__/transforms.test.js
@@ -1,5 +1,9 @@
 import { jest } from "@jest/globals";
 jest.autoMockOff();
+const mockUniqueId = "abc123";
+jest.unstable_mockModule("../../util.js", () => ({
+  uniqueId: jest.fn(() => mockUniqueId)
+}));
 import { defineInlineTest } from "../testUtils.js";
 
 import checkpointToDbSet from "../checkpoint-to-db-set.js";
@@ -7,7 +11,6 @@ import checkpointToDbGet from "../checkpoint-to-db-get.js";
 import paramsToProps from "../params-to-props.js";
 import authsToAuth from "../auths-to-auth.js";
 import programToExpression from "../program-to-expression.js";
-import namedExportToDollarExport from "../named-export-to-dollar-export.js";
 import sendToDotSend from "../send-to-dot-send.js";
 import respondToDotRespond from "../respond-to-dot-respond.js";
 import endToFlowExit from "../end-to-flow-exit.js";
@@ -18,7 +21,7 @@ import undefAssignmentToDeclaration from "../undef-assignment-to-declaration.js"
 import removeEmptyObject from "../remove-empty-object.js";
 import snakeToCamelCase from "../snake-to-camel-case.js";
 import cjsToEsm from "../cjs-to-esm.js";
-
+const namedExportToDollarExport = await import("../named-export-to-dollar-export.js");
 
 describe("params-to-props", () => {
   defineInlineTest(paramsToProps, {},
@@ -47,11 +50,35 @@ describe("auths-to-auth", () => {
 });
 
 describe("named-to-dollar-export", () => {
-  defineInlineTest(namedExportToDollarExport, {},
+  // TODO Allow any whitespacing in defineInlineTest input and output
+  defineInlineTest(namedExportToDollarExport, {}, // $.export is done in finally clause of try/finally
     "this.foo = \"bar\";",
-    "$.export(\"foo\", \"bar\");",
-    "transforms `this.__a = __b` to `$.export(\"__a\", __b)`"
+    `  let foo;
+
+  try {
+  foo = "bar";
+  } finally {
+    $.export("foo", foo);
+  }`,
+    "transforms `this.__a = __b` to `let __a = __b`"
   );
+
+  // TODO fix these tests
+  // defineInlineTest(namedExportToDollarExport, {}, `
+  //   this.foo = "bar";
+  //   const foo = "asdf"`, `
+  //   let foo_${mockUniqueId} = "bar";
+  //   const foo = "asdf"`,
+  // "transforms `this.__a = __b; const __a` to `let __a_uniqueId = __b; const __a`"
+  // );
+
+  // defineInlineTest(namedExportToDollarExport, {}, `
+  // this.foo = [];
+  // this.food.push(123);`, `
+  // let foo = [];
+  // foo.push(123);`,
+  // "transforms `this.__a = []; this.__a.push(123)` to `let __a = []; __a.push(123)`"
+  // );
 });
 
 describe("program-to-expression", () => {

--- a/lib/transforms/named-export-to-dollar-export.js
+++ b/lib/transforms/named-export-to-dollar-export.js
@@ -1,12 +1,23 @@
-import { register } from "../collections/ArrowFunctionExpression.js";
+import { uniqueId } from "../util.js";
+import { register } from "../collections/LegacyAction.js";
 register();
 
-// convert `this.__a = __b` to `$.export(__a, __b)`
+// convert `this.__a = __b` to `let __a; try { __a = __b; } finally { $.export("__a", __a) }`
 
+/**
+ * 
+ * @param {import("jscodeshift").FileInfo} fileInfo 
+ * @param {import("jscodeshift").API} api 
+ * @param {import("jscodeshift").Options} options 
+ * @returns 
+ */
 export default function(fileInfo, api, options) {
   const j = api.jscodeshift;
-
   const ast = j(fileInfo.source);
+  const mainBlock = ast.getFunctionExpression().get("body");
+  
+  const namedExports = new Set();
+  // Step 1: Find all named exports
   ast
     .find(j.ThisExpression)
     .filter((path) => {
@@ -18,16 +29,79 @@ export default function(fileInfo, api, options) {
       const parent = path.parent.node;
       return j.AssignmentExpression.check(parent) && parent.left === path.node;
     })
+    .forEach((path) => {
+      namedExports.add(path.value.property.name);
+    });
+
+  
+  // helper functions
+  const hasTryFinallyBlock = () => {
+    const mainBlockNode = mainBlock.get("body").value;
+    const lastNodeInMainBlock = mainBlockNode[mainBlockNode.length - 1];
+    return lastNodeInMainBlock.type === "TryStatement" && lastNodeInMainBlock.finalizer && !lastNodeInMainBlock.handler;
+  };
+  const createTryFinallyBlock = () => {
+    const tryFinally = j.tryStatement(
+      mainBlock.node,
+      null,
+      j.blockStatement([])
+    );
+    return tryFinally;
+  };
+
+  const namedExportToNewVarName = {};
+
+  // Step 2: For each named export, `this.__a`, generate:
+  /// ```js
+  // let __a; // or __a_uniqueId if __a already exists
+  // try { /* rest of code */ } finally { 
+  //   $.export("__a", __a)
+  // }
+  // ```
+  namedExports.forEach((namedExport) => {
+    // If a variable with the same name as the named export exists, generate a new name
+    const varOccurences = j(fileInfo.source).getFunctionExpression()
+      .getVariableOccurrences(namedExport);
+    const newVarName = varOccurences.size() ? `${namedExport}_${uniqueId()}` : namedExport;
+    namedExportToNewVarName[namedExport] = newVarName;
+    // Find or create try...finally block at bottom of code
+    if (!hasTryFinallyBlock()) {
+      mainBlock.replace(j.blockStatement([createTryFinallyBlock()]));
+    }
+    // Add $.export("namedExport", __newName) to finally block
+    const mainBlockNodeBody = mainBlock.get("body").value;
+    const finallyBlock = mainBlockNodeBody[mainBlockNodeBody.length - 1].finalizer.body;
+    finallyBlock.push(
+      j.expressionStatement(
+        j.callExpression(
+          j.memberExpression(j.identifier("$"), j.identifier("export")), [
+            j.literal(namedExport),
+            j.identifier(newVarName),
+          ]
+        )
+      )
+    );
+    // Add let __newName to start of code
+    mainBlock.get("body").unshift(
+      j.variableDeclaration("let", [
+        j.variableDeclarator(
+          j.identifier(newVarName)
+        )
+      ])
+    );
+  });
+
+  // Step 3: Replace this.__a with __a (or __a_uniqueId if __a already exists)
+  ast
+    .find(j.ThisExpression)
+    .filter((path) => {
+      const parent = path.parent.node;
+      return j.MemberExpression.check(parent) && parent.object === path.node;
+    })
     .map((path) => path.parent)
+    .filter((path) => namedExports.has(path.value.property.name))
     .replaceWith((path) => {
-      const exportName = path.value.left.property.name;
-      const exportValue = path.value.right;
-      return j.callExpression(
-        j.memberExpression(j.identifier("$"), j.identifier("export")), [
-          j.literal(exportName),
-          exportValue,
-        ]
-      );
+      return j.identifier(namedExportToNewVarName[path.value.property.name]);
     });
 
   return ast.toSource();

--- a/lib/transforms/named-export-to-dollar-export.js
+++ b/lib/transforms/named-export-to-dollar-export.js
@@ -4,13 +4,6 @@ register();
 
 // convert `this.__a = __b` to `let __a; try { __a = __b; } finally { $.export("__a", __a) }`
 
-/**
- * 
- * @param {import("jscodeshift").FileInfo} fileInfo 
- * @param {import("jscodeshift").API} api 
- * @param {import("jscodeshift").Options} options 
- * @returns 
- */
 export default function(fileInfo, api, options) {
   const j = api.jscodeshift;
   const ast = j(fileInfo.source);
@@ -52,7 +45,7 @@ export default function(fileInfo, api, options) {
   const namedExportToNewVarName = {};
 
   // Step 2: For each named export, `this.__a`, generate:
-  /// ```js
+  // ```js
   // let __a; // or __a_uniqueId if __a already exists
   // try { /* rest of code */ } finally { 
   //   $.export("__a", __a)

--- a/lib/transforms/testUtils.js
+++ b/lib/transforms/testUtils.js
@@ -19,6 +19,10 @@ function wrapCodeWithFunctionExpr(source) {
   return `async (params, auths) => {${source && `\n${source}\n`}}`;
 }
 
+/**
+ * Formats code text
+ * @param {String} source
+ */
 function formatText(source) {
   return prettier.format(source, { parser: "babel" });
 }  

--- a/lib/transforms/testUtils.js
+++ b/lib/transforms/testUtils.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import prettier from "prettier";
 import testUtils from "jscodeshift/dist/testUtils.js";
 const { applyTransform, runInlineTest } = testUtils;
 
@@ -17,6 +18,10 @@ function wrapCodeWithFunctionExpr(source) {
   }
   return `async (params, auths) => {${source && `\n${source}\n`}}`;
 }
+
+function formatText(source) {
+  return prettier.format(source, { parser: "babel" });
+}  
 
 // Source: https://bit.ly/3uBzenA
 function runTest(dirName, transformName, options, testFilePrefix, testOptions = {}, wrapCode=true) {
@@ -60,14 +65,28 @@ export function defineTest(dirName, transformName, options, testFilePrefix, test
   });
 }
 
-export function defineInlineTest(module, options, input, expectedOutput, testName, wrapCode=true) {
+export function defineInlineTest(
+  module,
+  testOptions,
+  input,
+  expectedOutput,
+  testName, {
+    wrapCode = true,
+    formatCode = false,
+  } = {}) {
+  let testInput = input;
+  let testExpectedOutput = expectedOutput;
   if (wrapCode) {
-    input = wrapCodeWithFunctionExpr(input);
-    expectedOutput = wrapCodeWithFunctionExpr(expectedOutput);
+    testInput = wrapCodeWithFunctionExpr(testInput);
+    testExpectedOutput = wrapCodeWithFunctionExpr(testExpectedOutput);
+  }
+  if (formatCode) {
+    testInput = formatText(testInput);
+    testExpectedOutput = formatText(testExpectedOutput);
   }
   it(testName || "transforms correctly", () => {
-    runInlineTest(module, options, {
-      source: input
-    }, expectedOutput);
+    runInlineTest(module, testOptions, {
+      source: testInput
+    }, testExpectedOutput);
   });
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,3 +1,4 @@
+import { customAlphabet } from "nanoid";
 import fs from "fs";
 import path from "path";
 import url from "url";
@@ -24,8 +25,14 @@ export function writeFile(filePath, content, { relative = false }={}) {
   fs.writeFileSync(filePath, content, "utf-8");
 }
 
+export function uniqueId() {
+  const nanoid = customAlphabet("1234567890abcdef", 6);
+  return nanoid();
+}
+
 export default {
   readFile,
   writeFile,
-  fixByteCharacters
+  fixByteCharacters,
+  uniqueId,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "minimist": "^1.2.5",
         "nanoid": "^4.0.2",
         "param-case": "^3.0.4",
+        "prettier": "^2.8.7",
         "putout": "^29.1.5",
         "safe-identifier": "^0.4.2"
       },
@@ -12237,6 +12238,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
@@ -23279,6 +23294,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+    },
+    "prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw=="
     },
     "pretty-format": {
       "version": "29.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "json2csv": "^5.0.6",
         "lodash.once": "^4.1.1",
         "minimist": "^1.2.5",
+        "nanoid": "^4.0.2",
         "param-case": "^3.0.4",
         "putout": "^29.1.5",
         "safe-identifier": "^0.4.2"
@@ -11570,14 +11571,20 @@
       "integrity": "sha512-/m8k0gPWeZUYW8yQDchzxAkHt9Sw5DT8h+6QtRGu23OUj3d7qCXfO9+RU2O/zptPM1+fJCi4Tku4XoYN8s7AYQ=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/natural-compare": {
@@ -12204,6 +12211,23 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -22806,9 +22830,9 @@
       "integrity": "sha512-/m8k0gPWeZUYW8yQDchzxAkHt9Sw5DT8h+6QtRGu23OUj3d7qCXfO9+RU2O/zptPM1+fJCi4Tku4XoYN8s7AYQ=="
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -23212,6 +23236,13 @@
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+        }
       }
     },
     "postcss-media-query-parser": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "minimist": "^1.2.5",
     "nanoid": "^4.0.2",
     "param-case": "^3.0.4",
+    "prettier": "^2.8.7",
     "putout": "^29.1.5",
     "safe-identifier": "^0.4.2"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "author": "",
   "license": "ISC",
+  "jest": {
+    "transform": {}
+  },
   "dependencies": {
     "@putout/plugin-remove-empty-pattern": "^4.2.2",
     "camelcase": "^7.0.1",
@@ -25,6 +28,7 @@
     "json2csv": "^5.0.6",
     "lodash.once": "^4.1.1",
     "minimist": "^1.2.5",
+    "nanoid": "^4.0.2",
     "param-case": "^3.0.4",
     "putout": "^29.1.5",
     "safe-identifier": "^0.4.2"


### PR DESCRIPTION
This pull request fixes conversion of references to named exports used outside of assignment expressions.

Named exports were being transformed to dollar exports only when used in an assignment expression (e.g. `this.foo = 5`), but not in other expressions (e.g., `this.foo.push("hello")` after `this.foo = []`). In this PR, named exports are transformed as follows:

1. Wrap the action code in a `try...finally` statement
2. Declare a variable with the same name as the named export (with an appended unique ID if there's a conflict) at the top of the action code, above the `try...finally` statement
3. Convert all instances of `this.<named export>` to the variable declared in step 2
4. Add a dollar export call for the named export to the to the `finally` block

For example:

- Input:
   ```js
  this.projects = [];
  this.projects.push("project1");
  return this.projects;
   ```
- Output:
  ```js
  let projects;
  try {
    projects = [];
    projects.push("project1");
    return projects;
  } finally {
    $.export("projects", projects);
  }
  ```