### PR TITLE
feat: add steps arg to generated run method

### DIFF
--- a/resources/templates/action-cjs.handlebars
+++ b/resources/templates/action-cjs.handlebars
@@ -24,7 +24,7 @@ module.exports = {
     {{> componentProp }}
   {{/each}}
   },
-  async run({ $ }) {{{code}}}
+  async run({ steps, $ }) {{{code}}}
 {{/inline}}
 
 {{~#*inline "componentProp"}}


### PR DESCRIPTION
Include `steps` as an argument for the generated `run` method if `steps` is read within the action.

Example:
- Input:
```js
console.log(steps.code.foo);
```
- Output:
```js
export default {
  // ...
  async run({ steps }) {
    console.log(steps.code.foo);
  },
});
```

Partially addresses: #8 