### PR TITLE
feat(transforms): convert $checkpoint using data_store prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Config
 - `auths.<app_name_slug>` -> app_name_slug (defaults to `app_placeholder`)
 
 Code
-- `this.$checkpoint = "value` -> `let stepCheckpoint = await this.db.get("scp_${uid}"); try { stepCheckpoint = "value" } finally { await this.db.set("scp_${uid}") }` (+ `data_store` prop)
+- `this.$checkpoint = "value` -> `let stepCheckpoint = await this.db.get("scp_${uid}"); try { stepCheckpoint = "value" } finally { await this.db.set("scp_${uid}", stepCheckpoint) }` (+ `data_store` prop)
+- `$checkpoint = "value` -> `let $checkpoint = await this.db.get("$checkpoint"); try { $checkpoint = "value" } finally { await this.db.set("$checkpint", $checkpoint) }` (+ `data_store` prop)
 - `$send` -> `$.send`
 - `$respond` -> `$.respond`
 - `$end` -> `$.flow.exit`

--- a/lib/collections/LegacyAction.js
+++ b/lib/collections/LegacyAction.js
@@ -72,6 +72,34 @@ const globalMethods = {
   hasTryFinallyBlock: function() {
     return Boolean(this.getTryFinallyBlock());
   },
+
+  /**
+   * Returns an await expression that calls the specified method with the
+   * specified key and arguments on the db object
+   * 
+   * @example
+   * // returns `await this.db.get("foo")`
+   * ast.createDataStoreCall(j, "get", "foo")
+   * @example
+   * // returns `await this.db.set("foo", "bar")`
+   * ast.createDataStoreCall(j, "set", "foo", j.literal("bar"))
+   * 
+   * @param {import("jscodeshift").JSCodeshift} j 
+   * @param {String} methodName 
+   * @param {String} key 
+   * @param  {...any} args 
+   * @returns the await expression
+   */
+  createDataStoreCall: function(j, methodName = "get", key, ...args) {
+    return j.awaitExpression(
+      j.callExpression(
+        j.memberExpression(
+          j.memberExpression(j.thisExpression(), j.identifier("db")),
+          j.identifier(methodName),
+        ),
+        [j.literal(key), ...args]
+      ));
+  },
 };
 
 /**

--- a/lib/collections/LegacyAction.js
+++ b/lib/collections/LegacyAction.js
@@ -111,6 +111,21 @@ const traversalMethods = {
       .filter((path) => path.value.id.properties.length === 1);
   },
 
+  getLegacyCodeCellVars: function(name) {
+    return this.find(types.Identifier)
+      .filter((path) => {
+        return path.node.name === name;
+      })
+      .filter((path) => {
+        const parent = path.parent.node;
+        const isMemberProperty =
+          types.MemberExpression.check(parent)
+          && parent.property === path.node;
+        // must not be a property (e.g., foo.<name>)
+        return !isMemberProperty;
+      });
+  },
+
   /**
    * Finds occurrences of `this.$checkpoint` assignment expressions
    * 

--- a/lib/getters/workflow-checkpoints.js
+++ b/lib/getters/workflow-checkpoints.js
@@ -1,0 +1,12 @@
+import jscodeshift from "jscodeshift/dist/core.js";
+import { register } from "../collections/LegacyAction.js";
+register();
+
+export default function(fileInfo) {
+  const j = jscodeshift;
+
+  const ast = j(fileInfo.source);
+  return ast
+    .getLegacyCodeCellVars("$checkpoint")
+    .nodes();
+}

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,13 +1,15 @@
 import getAuths from "./getters/auths.js";
 import getCheckpointAssignments from "./getters/checkpoint-assignments.js";
 import getCheckpointExpressions from "./getters/checkpoint-expressions.js";
+import getWorkflowCheckpoints from "./getters/workflow-checkpoints.js";
 
 function parse(source) {
   const checkpointAssignments = getCheckpointAssignments({ source });
   const checkpointExpressions = getCheckpointExpressions({ source });
+  const workflowCheckpoints = getWorkflowCheckpoints({ source });
   const auths = getAuths({ source });
   return {
-    checkpoints: [...checkpointAssignments, ...checkpointExpressions],
+    checkpoints: [...checkpointAssignments, ...checkpointExpressions, ...workflowCheckpoints],
     auths,
   };
 }

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -13,11 +13,13 @@ import removeUnusedAxios from "./transforms/remove-unused-axios.js";
 import attachmentsToStepsAttachments from "./transforms/attachments-to-steps-attachments.js";
 import eventToStepsEvent from "./transforms/event-to-steps-event.js";
 import stepCheckpointToDataStore from "./transforms/step-checkpoint-to-data_store.js";
+import workflowCheckpointToDataStore from "./transforms/workflow-checkpoint-to-data_store.js";
 
 
 function legacyToComponentCode(source) {
   return applyTransforms(source, [
     stepCheckpointToDataStore,
+    workflowCheckpointToDataStore,
     sendToDotSend,
     respondToDotRespond,
     endToFlowExit,

--- a/lib/transforms/__tests__/transforms.test.js
+++ b/lib/transforms/__tests__/transforms.test.js
@@ -21,6 +21,7 @@ import snakeToCamelCase from "../snake-to-camel-case.js";
 import cjsToEsm from "../cjs-to-esm.js";
 import attachmentsToStepsAttachments from "../attachments-to-steps-attachments.js";
 import eventToStepsEvent from "../event-to-steps-event.js";
+import workflowCheckpointToDataStore from "../workflow-checkpoint-to-data_store.js";
 // To mock ESM modules using Jest, need to use dynamic import() after jest.mock
 // calls to load the mocked modules
 const namedExportToDollarExport = await import("../named-export-to-dollar-export.js");
@@ -330,6 +331,36 @@ describe("step-checkpoint-to-data_store", () => {
       }
     `,
     "transforms `this.$checkpoint` even when `this.$checkpoint` is not assigned to",
+    { formatCode: true }
+  );
+});
+
+describe("workflow-checkpoint-to-data_store", () => {
+  defineInlineTest(workflowCheckpointToDataStore, {},
+    "$checkpoint = 5",
+    `let $checkpoint = await this.db.get("$checkpoint");
+
+      try {
+        $checkpoint = 5;
+      } finally {
+        await this.db.set("$checkpoint", $checkpoint);
+      }
+    `,
+    "transforms `$checkpoint` assignment to get and set from data_store in try...finally",
+    { formatCode: true }
+  );
+
+  defineInlineTest(workflowCheckpointToDataStore, {},
+    "const foo = $checkpoint",
+    `let $checkpoint = await this.db.get("$checkpoint");
+
+      try {
+        const foo = $checkpoint;
+      } finally {
+        await this.db.set("$checkpoint", $checkpoint);
+      }
+    `,
+    "transforms `$checkpoint` even when `$checkpoint` is not assigned to",
     { formatCode: true }
   );
 });

--- a/lib/transforms/attachments-to-steps-attachments.js
+++ b/lib/transforms/attachments-to-steps-attachments.js
@@ -6,16 +6,7 @@ export default function(fileInfo, api, options) {
   const ast = j(fileInfo.source);
 
   ast
-    .find(j.Identifier)
-    .filter((path) => {
-      return path.node.name === "$attachments";
-    })
-    .filter((path) => {
-      const parent = path.parent.node;
-      const isMemberProperty = j.MemberExpression.check(parent) && parent.property === path.node;
-      // $attachments must not be a property (e.g., foo.$attachments)
-      return !isMemberProperty;
-    })
+    .getLegacyCodeCellVars("$attachments")
     .replaceWith(() => j.memberExpression(
       j.memberExpression(
         j.memberExpression(

--- a/lib/transforms/event-to-steps-event.js
+++ b/lib/transforms/event-to-steps-event.js
@@ -1,3 +1,6 @@
+import { register } from "../collections/LegacyAction.js";
+register();
+
 // replace `event` with `steps.trigger.event`
 
 export default function(fileInfo, api, options) {
@@ -6,16 +9,7 @@ export default function(fileInfo, api, options) {
   const ast = j(fileInfo.source);
 
   ast
-    .find(j.Identifier)
-    .filter((path) => {
-      return path.node.name === "event";
-    })
-    .filter((path) => {
-      const parent = path.parent.node;
-      const isMemberProperty = j.MemberExpression.check(parent) && parent.property === path.node;
-      // event must not be a property (e.g., foo.event)
-      return !isMemberProperty;
-    })
+    .getLegacyCodeCellVars("event")
     .replaceWith(() => j.memberExpression(
       j.memberExpression(
         j.identifier("steps"),

--- a/lib/transforms/step-checkpoint-to-data_store.js
+++ b/lib/transforms/step-checkpoint-to-data_store.js
@@ -18,17 +18,6 @@ export default function(fileInfo, api, options) {
 
   const checkpointVarName = "stepCheckpoint";
 
-  const createDataStoreCall = (methodName = "get", scpId, ...args) => {
-    return j.awaitExpression(
-      j.callExpression(
-        j.memberExpression(
-          j.memberExpression(j.thisExpression(), j.identifier("db")),
-          j.identifier(methodName),
-        ),
-        [j.literal(scpId), ...args]
-      ));
-  };
-
   const checkpointExpressions = ast.getCheckpointExpressions();
   // If there's at least one checkpoint expression:
   //  1. Find or create try...finally statement
@@ -39,14 +28,14 @@ export default function(fileInfo, api, options) {
     const tryFinallyBlock = ast.getOrAddTryFinallyBlock(j);
     const finallyBlock = tryFinallyBlock.finalizer.body;
     finallyBlock.push(j.expressionStatement(
-      createDataStoreCall("set", scpId, j.identifier(checkpointVarName))
+      ast.createDataStoreCall(j, "set", scpId, j.identifier(checkpointVarName))
     ));
     const mainBlock = ast.getMainBlock();
     mainBlock.get("body").unshift(
       j.variableDeclaration("let", [
         j.variableDeclarator(
           j.identifier(checkpointVarName),
-          createDataStoreCall("get", scpId)
+          ast.createDataStoreCall(j, "get", scpId)
         )
       ])
     );

--- a/lib/transforms/workflow-checkpoint-to-data_store.js
+++ b/lib/transforms/workflow-checkpoint-to-data_store.js
@@ -1,0 +1,44 @@
+import { register } from "../collections/LegacyAction.js";
+register();
+
+// convert `$checkpoint = __a` to
+// ```
+// let $checkpoint = await this.db.get("$checkpoint");
+// try {
+//  $checkpoint = __a;
+// } finally {
+//   await this.db.set("$checkpoint", $checkpoint); 
+// }
+// ```
+
+export default function(fileInfo, api, options) {
+  const j = api.jscodeshift;
+  const ast = j(fileInfo.source);
+
+  const checkpointVarName = "$checkpoint";
+  const checkpointDBKey = "$checkpoint";
+
+  const checkpointExpressions = ast.getLegacyCodeCellVars("$checkpoint");
+  // If there's at least one checkpoint expression:
+  //  1. Find or create try...finally statement
+  //  2. Add `await this.db.set("$checkpoint", $checkpoint)` to finally block
+  //  3. Add `let $checkpoint = await this.db.get("$checkpoint")` before try...finally
+  if (checkpointExpressions.size()) {
+    const tryFinallyBlock = ast.getOrAddTryFinallyBlock(j);
+    const finallyBlock = tryFinallyBlock.finalizer.body;
+    finallyBlock.push(j.expressionStatement(
+      ast.createDataStoreCall(j, "set", checkpointDBKey, j.identifier(checkpointVarName))
+    ));
+    const mainBlock = ast.getMainBlock();
+    mainBlock.get("body").unshift(
+      j.variableDeclaration("let", [
+        j.variableDeclarator(
+          j.identifier(checkpointVarName),
+          ast.createDataStoreCall(j, "get", checkpointDBKey)
+        )
+      ])
+    );
+  }
+
+  return ast.toSource();
+}


### PR DESCRIPTION
**Changes**

* refactor: create collection traversal method for legacy code cell vars (`$attachments`, `event`, `$checkpoint`)
* refactor: move `createDataStoreCall` from step checkpoint transform to LegacyAction collection global method
* add transform for `$checkpoint` using data_store prop

**Details**

Get the [worfklow] $checkpoint value from the data store, async, at the start of the action and set it at the end of the action. Use a try...finally statement to ensure the value is set even if the action throws an error.

For example:

- Input:

```js
$checkpoint ||= {}
$checkpoint["foo"] = "bar"
```

- Output:

```js
const $checkpoint = await this.db.get("$checkpoint")
try {
  $checkpoint ||= {}
  $checkpoint["foo"] = "bar"
} finally {
  await this.db.set("$checkpoint", $checkpoint)
}
```

Partially addresses: #8