### PR TITLE
fix(transforms): var conflicts in cjs-to-esm require-to-import transform

### DIFF
--- a/lib/transforms/__tests__/transforms.test.js
+++ b/lib/transforms/__tests__/transforms.test.js
@@ -267,6 +267,32 @@ describe("cjs-to-esm", () => {
     "transforms `require(\"foo-bar\")(5)` to `fooBar(5)` and `import fooBar from \"foo-bar\"`",
     { wrapCode: false }
   );
+  defineInlineTest(cjsToEsm, {},
+    `require("foo-bar")(5);
+      const fooBar = "hello world";
+      console.log(fooBar);
+    `,
+    `import fooBarModule from "foo-bar";
+      fooBarModule(5);
+      const fooBar = "hello world";
+      console.log(fooBar);
+    `,
+    "Renames import default specifier to avoid var name conflict",
+    { wrapCode: false, formatCode: true }
+  );
+  defineInlineTest(cjsToEsm, {},
+    `const bar = "hello world";
+      require("foo").bar(5);
+      console.log(bar);
+    `,
+    `import { bar as fooBar } from "foo";
+      const bar = "hello world";
+      fooBar(5);
+      console.log(bar);
+    `,
+    "Renames import specifier to avoid name conflict",
+    { wrapCode: false, formatCode: true }
+  );
 });
 
 describe("attachments-to-steps-attachments", () => {

--- a/lib/transforms/cjs-to-esm.js
+++ b/lib/transforms/cjs-to-esm.js
@@ -95,31 +95,31 @@ export default function(fileInfo, api, options) {
         && j.Identifier.check(path.parent.value.property);
     })
     .forEach((path) => {
-      const sourceValue = path.get("arguments", 0).value.value;
+      const moduleName = path.get("arguments", 0).value.value;
       const propertyName = path.parent.value.property.name;
       // Hack? Convert `require("__a").default` to `__aModule.default` and
       // `import __aModule from "__a"` instead
       if (propertyName === "default") {
-        const moduleName = camelcase(identifier(`${sourceValue}Module`));
-        prependDefaultImport(moduleName, sourceValue);
-        path.replace(j.identifier(moduleName));
+        const defaultImportName = camelcase(identifier(`${moduleName}Module`));
+        prependDefaultImport(defaultImportName, moduleName);
+        path.replace(j.identifier(defaultImportName));
         return;
       }
-      if (hasImport(propertyName, sourceValue)) {
+      if (hasImport(propertyName, moduleName)) {
         path.parent.replace(j.identifier(propertyName));
         return;
       }
-      // If a variable with the same name as the imported property exists,
-      // import the property as the conctenation of the package name and
-      // property name
-      let fnName = propertyName;
+      // If a variable with the same name as the new named import exists, alias
+      // the named import as the conctenation of the package name and property
+      // name
+      let importLocalName = propertyName;
       if (path.scope.lookup(propertyName)) {
-        fnName = varname.camelback(`${sourceValue}-${propertyName}`);
-        prependImport([{ imported: propertyName, local: fnName }], sourceValue);
+        importLocalName = varname.camelback(`${moduleName}-${propertyName}`);
+        prependImport([{ imported: propertyName, local: importLocalName }], moduleName);
       } else {
-        prependImport([propertyName], sourceValue);
+        prependImport([propertyName], moduleName);
       }
-      path.parent.replace(j.identifier(fnName));
+      path.parent.replace(j.identifier(importLocalName));
     });
 
   // Convert `{ __b } = require("__a")` to `import { __b } from "__a"` at top level
@@ -157,15 +157,15 @@ export default function(fileInfo, api, options) {
   //  `import camelCase(__a) from "__a" at top level
   ast.getRequireCalls()
     .forEach((path) => {
-      const sourceValue = path.get("arguments", 0).value.value;
-      let fnName = camelcase(sourceValue);
-      // If a variable with the same name as the default import name exists,
-      // append "Module"
-      if (path.scope.lookup(fnName)) {
-        fnName += "Module";
-      }
-      prependDefaultImport(fnName, sourceValue);
-      path.replace(j.identifier(fnName));
+      const moduleName = path.get("arguments", 0).value.value;
+      const camelCaseModuleName = camelcase(moduleName);
+      // If a variable with the same name as the camelCase module name exists,
+      // append "Module" to the new default import name
+      const defaultImportName = path.scope.lookup(camelCaseModuleName)
+        ? `${camelCaseModuleName}Module`
+        : camelCaseModuleName;
+      prependDefaultImport(defaultImportName, moduleName);
+      path.replace(j.identifier(defaultImportName));
     });
 
   // If the first node has been modified or deleted, reattach the comments

--- a/lib/transforms/cjs-to-esm.js
+++ b/lib/transforms/cjs-to-esm.js
@@ -1,14 +1,21 @@
 import { register } from "../collections/LegacyAction.js";
 import { identifier } from "safe-identifier";
 import camelcase from "camelcase";
+import varname from "varname";
 register();
 
-// Convert `module.exports = ` to `export default`
-// Convert `__b = require("__a")` to `import __b from "__a"`
-// Convert `{ __b } = require("__a")` to `import { __b } from "__a"` at top level
-// Convert `require("__a").__c` to `__c` and `import { __c } from "__a"` at top level
-// Convert `require("__a")(__b)` to `camelCase(__a)(__b)` and 
-//  `import camelCase(__a) from "__a" at top level
+// - Convert `module.exports = ` to `export default`
+// - Convert `__b = require("__a")` to `import __b from "__a"`
+// - Convert `{ __b } = require("__a")` to `import { __b } from "__a"` at top level
+// - Convert `require("__a").__c` to `__c` and `import { __c } from "__a"` at top level
+// - If a variable called __c already exists:
+//    Convert `require("__a").__c` to `camelCase(__a-__c)` and
+//    `import { __c: camelCase(__a-__c) }` at top level
+// - Convert `require("__a")(__b)` to `camelCase(__a)(__b)` and 
+//    `import camelCase(__a) from "__a" at top level
+// - If a variable called camelCase(__a) already exists:
+//    Convert `require("__a")(__b)` to `camelCase(__a)Module(__b)` and
+//    `import camelCase(__a)Module from "__a" at top level
 
 export default function(fileInfo, api, options) {
   const j = api.jscodeshift;
@@ -89,24 +96,28 @@ export default function(fileInfo, api, options) {
     })
     .forEach((path) => {
       const sourceValue = path.get("arguments", 0).value.value;
-      let fnName = path.parent.value.property.name;
+      const propertyName = path.parent.value.property.name;
       // Hack? Convert `require("__a").default` to `__aModule.default` and
       // `import __aModule from "__a"` instead
-      if (fnName === "default") {
+      if (propertyName === "default") {
         const moduleName = camelcase(identifier(`${sourceValue}Module`));
         prependDefaultImport(moduleName, sourceValue);
         path.replace(j.identifier(moduleName));
         return;
       }
-      // Hack to fix duplicate axios var when axios and pipedream axios are used
-      if (
-        fnName === "axios" && sourceValue !== "axios"
-        && (ast.getRequireCalls("axios").size() > 0 || ast.getImports("axios").size() > 0)
-      ) {
-        fnName = "pipedreamAxios";
-        prependImport([{ imported: "axios", local: fnName }], sourceValue);
+      if (hasImport(propertyName, sourceValue)) {
+        path.parent.replace(j.identifier(propertyName));
+        return;
+      }
+      // If a variable with the same name as the imported property exists,
+      // import the property as the conctenation of the package name and
+      // property name
+      let fnName = propertyName;
+      if (path.scope.lookup(propertyName)) {
+        fnName = varname.camelback(`${sourceValue}-${propertyName}`);
+        prependImport([{ imported: propertyName, local: fnName }], sourceValue);
       } else {
-        prependImport([fnName], sourceValue);
+        prependImport([propertyName], sourceValue);
       }
       path.parent.replace(j.identifier(fnName));
     });
@@ -147,7 +158,12 @@ export default function(fileInfo, api, options) {
   ast.getRequireCalls()
     .forEach((path) => {
       const sourceValue = path.get("arguments", 0).value.value;
-      const fnName = camelcase(sourceValue);
+      let fnName = camelcase(sourceValue);
+      // If a variable with the same name as the default import name exists,
+      // append "Module"
+      if (path.scope.lookup(fnName)) {
+        fnName += "Module";
+      }
       prependDefaultImport(fnName, sourceValue);
       path.replace(j.identifier(fnName));
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "param-case": "^3.0.4",
         "prettier": "^2.8.7",
         "putout": "^29.1.5",
-        "safe-identifier": "^0.4.2"
+        "safe-identifier": "^0.4.2",
+        "varname": "^5.0.1"
       },
       "devDependencies": {
         "jest": "^29.5.0"
@@ -14624,6 +14625,15 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/varname": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/varname/-/varname-5.0.1.tgz",
+      "integrity": "sha512-dsoHc1qPg5obVxxrefAzr1x27U1pFfAE5kcFj96QZonSPuEKVacR1Lpc3WO9q7h6nFk1qXL2ZdY3bc7Ng+NcWA==",
+      "engines": {
+        "node": "16.x || 18.x || 20.x",
+        "npm": "8.x || 9.x"
+      }
+    },
     "node_modules/vfile": {
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
@@ -25049,6 +25059,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "varname": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/varname/-/varname-5.0.1.tgz",
+      "integrity": "sha512-dsoHc1qPg5obVxxrefAzr1x27U1pFfAE5kcFj96QZonSPuEKVacR1Lpc3WO9q7h6nFk1qXL2ZdY3bc7Ng+NcWA=="
     },
     "vfile": {
       "version": "5.3.7",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "param-case": "^3.0.4",
     "prettier": "^2.8.7",
     "putout": "^29.1.5",
-    "safe-identifier": "^0.4.2"
+    "safe-identifier": "^0.4.2",
+    "varname": "^5.0.1"
   },
   "devDependencies": {
     "jest": "^29.5.0"


### PR DESCRIPTION
When name of imported module is same as name of variable in scope, it causes a conflict. This PR fixes that by renaming the imported module to `${pckgName}Module`, if it's a default import.

For example:
- Input:
```js
  require("foo-bar")(5);
  const fooBar = "hello world";
  console.log(fooBar);
```

- Output before :x::
```js
  import fooBar from "foo-bar";
  fooBar(5);
  const fooBar = "hello world";
  console.log(fooBar);
```

- Output after ✅:
```js
  import fooBarModule from "foo-bar";
  fooBarModule(5);
  const fooBar = "hello world";
  console.log(fooBar);
```

When the imported module is a named import, it's renamed to `${pckgName}${importedName}`.

For example:
- Input:
```js
  const bar = "hello world";
  require("foo").bar(5);
  console.log(bar);
```

- Output before :x::
```js
  import { bar } from "foo";
  const bar = "hello world";
  bar(5);
  console.log(bar);
```

- Output after ✅:
```js
  import { bar as fooBar } from "foo";
  const bar = "hello world";
  fooBar(5);
  console.log(bar);
```

Part of #50 