### PR TITLE
fix: browser compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Fixes
 - Removes unused variables (eslint no-unused-var)
 - Converts variables to camelCase (eslint camelcase)
 - Converts code from CommonJS to ESModules
-- Fix eslint-fixable eslint errors
+- Fix eslint-fixable eslint errors (unsupported in browser)
 
 # Examples
 ###### _Created with v0.4.1-lw_

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,30 @@
+export interface ActionConfig {
+  code: string
+  title?: string
+  description?: string;
+  namespace?: string;
+  codeConfig?: string;
+  versionMajor?: string | number;
+  versionMinor?: string | number;
+  versionPatch?: string | number;
+  hashId?: string;
+}
+
+export interface ConvertOptions {
+  defineComponent?: boolean = false;
+  createLabel?: boolean = false;
+  toEsm?: boolean = true;
+  usePipedreamLintRules?: boolean = true;
+  appPlaceholder?: string = "app_placeholder";
+  addPlaceholderAppProp?: boolean = false;
+}
+
+export interface ConvertResult {
+  code: string;
+  appSlug?: string;
+  componentSlug?: string;
+  legacyHashId?: string;
+  componentKey?: string;
+}
+
+export declare function convert(actionConfig: ActionConfig, options: ConvertOptions): Promise<ConvertResult>

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -120,7 +120,7 @@ async function convert({
   } catch (err) {
     throw new Error(`Invalid code config: ${err.message}`);
   }
-  if (typeof paramsSchema !== "object") {
+  if (paramsSchema && typeof paramsSchema !== "object") {
     throw new Error("Invalid code config: paramsSchema must be an object");
   }
 

--- a/lib/fix.js
+++ b/lib/fix.js
@@ -1,6 +1,4 @@
-import { ESLint } from "eslint";
-import putout from "putout";
-import { fixByteCharacters, readFile } from "./util.js";
+import { fixByteCharacters, isNode, readFile } from "./util.js";
 import { applyTransforms } from "./transforms/testUtils.js";
 import undefAssignmentToDeclaration from "./transforms/undef-assignment-to-declaration.js";
 import removeEmptyObject from "./transforms/remove-empty-object.js";
@@ -18,31 +16,37 @@ import cjsToEsm from "./transforms/cjs-to-esm.js";
  * @param {object} [options={}]
  * @returns {string}
  */
-function preFixErrors(source, { toEsm }={}) {
+async function preFixErrors(source, { toEsm }={}) {
   let code = applyTransforms(source, [ undefAssignmentToDeclaration ]);
-  code = putout(code, {
-    plugins: [
-      "remove-unused-variables",
-      "remove-empty-pattern"
-    ],
-  }).code;
+  if (isNode()) {
+    const { default: putout } = await import("putout");
+    code = putout(code, {
+      plugins: [
+        "remove-unused-variables",
+        "remove-empty-pattern"
+      ],
+    }).code;
+  }
   code = applyTransforms(code, [
     removeEmptyObject,
     snakeToCamelCase,
-    ...(toEsm ? [cjsToEsm] : [])
+    ...(toEsm ? [cjsToEsm] : []),
   ]);
   return code;
 }
 
 
 async function lintAndFix(source, { configFile="../resources/.eslint-pipedream.json" }={}) {
+  const { ESLint } = await import("eslint");
   const eslintConfig = JSON.parse(readFile(configFile, { relative: true }));
   const eslint = new ESLint({
     useEslintrc: false,
     overrideConfig: eslintConfig,
     fix: true
   });
-  const results = await eslint.lintText(source, { filePath: "components/app_slug/actions/comp_slug/comp_slug.js" });
+  const results = await eslint.lintText(source, {
+    filePath: "components/app_slug/actions/comp_slug/comp_slug.js"
+  });
   const [result] = results;
   const { output, messages } = result;
   for (const message of messages) {
@@ -61,12 +65,14 @@ async function lintAndFix(source, { configFile="../resources/.eslint-pipedream.j
  */
 async function fix(source, { toEsm, usePipedreamLintRules = true }={}) {
   let code = fixByteCharacters(source);
-  code = preFixErrors(code, { toEsm });
-  code = await lintAndFix(code, {
-    configFile: usePipedreamLintRules
-      ? "../resources/.eslint-pipedream.json"
-      : "../resources/.eslint-default.json"
-  });
+  code = await preFixErrors(code, { toEsm });
+  if (isNode()) {
+    code = await lintAndFix(code, {
+      configFile: usePipedreamLintRules
+        ? "../resources/.eslint-pipedream.json"
+        : "../resources/.eslint-default.json"
+    });
+  }
   return code;
 }
 

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,7 +1,5 @@
 import Handlebars from "handlebars";
-// import { readFile } from "./util.js";
 
-// const TEMPLATE_PATH = "../resources/templates/action-cjs.handlebars";
 import actionCjsTemplate from "../resources/templates/action-cjs.js";
 
 Handlebars.registerHelper("isdefined", function (value) {
@@ -22,7 +20,6 @@ function generateComponent(
   { code, props, name, description, key, version, hashId },
   { defineComponent } = {}
 ) {
-  // const templateString = readFile(TEMPLATE_PATH, { relative: true });
   const template = Handlebars.compile(actionCjsTemplate, { noEscape: true });
   return template({ code, props, name, description, key, version, defineComponent, hashId });
 }

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,7 +1,8 @@
 import Handlebars from "handlebars";
-import { readFile } from "./util.js";
+// import { readFile } from "./util.js";
 
-const TEMPLATE_PATH = "../resources/templates/action-cjs.handlebars";
+// const TEMPLATE_PATH = "../resources/templates/action-cjs.handlebars";
+import actionCjsTemplate from "../resources/templates/action-cjs.js";
 
 Handlebars.registerHelper("isdefined", function (value) {
   return value !== undefined;
@@ -21,8 +22,8 @@ function generateComponent(
   { code, props, name, description, key, version, hashId },
   { defineComponent } = {}
 ) {
-  const templateString = readFile(TEMPLATE_PATH, { relative: true });
-  const template = Handlebars.compile(templateString, { noEscape: true });
+  // const templateString = readFile(TEMPLATE_PATH, { relative: true });
+  const template = Handlebars.compile(actionCjsTemplate, { noEscape: true });
   return template({ code, props, name, description, key, version, defineComponent, hashId });
 }
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -15,9 +15,19 @@ import eventToStepsEvent from "./transforms/event-to-steps-event.js";
 import stepCheckpointToDataStore from "./transforms/step-checkpoint-to-data_store.js";
 import workflowCheckpointToDataStore from "./transforms/workflow-checkpoint-to-data_store.js";
 
+/**
+ * @param {string} expression 
+ * @returns the body of the expression, without the surrounding braces
+ */
+function expressionBody(expression) {
+  const lines = expression.split("\n");
+  return lines.slice(1, lines.length - 1)
+    .map(line => line.replace("  ", ""))
+    .join("\n");
+}
 
 function legacyToComponentCode(source) {
-  return applyTransforms(source, [
+  const componentCodeExpression = applyTransforms(source, [
     stepCheckpointToDataStore,
     workflowCheckpointToDataStore,
     sendToDotSend,
@@ -33,6 +43,7 @@ function legacyToComponentCode(source) {
     removeUnusedAxios,
     programToExpression
   ]);
+  return expressionBody(componentCodeExpression);
 }
 
 function transform(source) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,14 +2,15 @@ import { customAlphabet } from "nanoid";
 import fs from "fs";
 import path from "path";
 import url from "url";
-const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
 export function fixByteCharacters(string) {
   return string.replace(/[]/g, "'"); // invisible character, supposed to be (’)
 }
 
 export function makeFilePath(filePath, relative=false) {
-  return relative ? path.join(__dirname, filePath) : filePath;
+  return relative ?
+    path.join(url.fileURLToPath(new URL(".", import.meta.url)), filePath)
+    : filePath;
 }
 
 export function readFile(filePath, { relative = false }={}) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -31,9 +31,16 @@ export function uniqueId() {
   return nanoid();
 }
 
+export function isNode() {
+  return typeof process !== "undefined" &&
+    process.versions != null &&
+    process.versions.node != null;
+}
+
 export default {
   readFile,
   writeFile,
   fixByteCharacters,
   uniqueId,
+  isNode,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@putout/plugin-remove-empty-pattern": "^4.2.2",
+        "acorn-stage3": "^4.0.0",
         "camelcase": "^7.0.1",
         "csvtojson": "^2.0.10",
         "eslint": "^8.36.0",
@@ -18,6 +19,7 @@
         "eslint-plugin-pipedream": "^0.2.4",
         "eslint-plugin-putout": "^17.1.0",
         "handlebars": "^4.7.7",
+        "hermes-parser": "^0.11.1",
         "inquirer": "^9.1.5",
         "jscodeshift": "^0.14.0",
         "json2csv": "^5.0.6",
@@ -28,6 +30,7 @@
         "prettier": "^2.8.7",
         "putout": "^29.1.5",
         "safe-identifier": "^0.4.2",
+        "tenko": "^2.0.1",
         "varname": "^5.0.1"
       },
       "devDependencies": {
@@ -5269,12 +5272,81 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-class-fields": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.3.7.tgz",
+      "integrity": "sha512-jdUWSFce0fuADUljmExz4TWpPkxmRW/ZCPRqeeUzbGf0vFUcpQYbyq52l75qGd0oSwwtAepeL6hgb/naRgvcKQ==",
+      "dependencies": {
+        "acorn-private-class-elements": "^0.2.7"
+      },
+      "engines": {
+        "node": ">=4.8.2"
+      },
+      "peerDependencies": {
+        "acorn": "^6 || ^7 || ^8"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-private-class-elements": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.7.tgz",
+      "integrity": "sha512-+GZH2wOKNZOBI4OOPmzpo4cs6mW297sn6fgIk1dUI08jGjhAaEwvC39mN2gJAg2lmAQJ1rBkFqKWonL3Zz6PVA==",
+      "engines": {
+        "node": ">=4.8.2"
+      },
+      "peerDependencies": {
+        "acorn": "^6.1.0 || ^7 || ^8"
+      }
+    },
+    "node_modules/acorn-private-methods": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-private-methods/-/acorn-private-methods-0.3.3.tgz",
+      "integrity": "sha512-46oeEol3YFvLSah5m9hGMlNpxDBCEkdceJgf01AjqKYTK9r6HexKs2rgSbLK81pYjZZMonhftuUReGMlbbv05w==",
+      "dependencies": {
+        "acorn-private-class-elements": "^0.2.7"
+      },
+      "engines": {
+        "node": ">=4.8.2"
+      },
+      "peerDependencies": {
+        "acorn": "^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/acorn-stage3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-stage3/-/acorn-stage3-4.0.0.tgz",
+      "integrity": "sha512-BR+LaADtA6GTB5prkNqWmlmCLYmkyW0whvSxdHhbupTaro2qBJ95fJDEiRLPUmiACGHPaYyeH9xmNJWdGfXRQw==",
+      "dependencies": {
+        "acorn-class-fields": "^0.3.7",
+        "acorn-private-methods": "^0.3.3",
+        "acorn-static-class-features": "^0.2.4"
+      },
+      "engines": {
+        "node": ">=4.8.2"
+      },
+      "peerDependencies": {
+        "acorn": "^7.4 || ^8"
+      }
+    },
+    "node_modules/acorn-static-class-features": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/acorn-static-class-features/-/acorn-static-class-features-0.2.4.tgz",
+      "integrity": "sha512-5X4mpYq5J3pdndLmIB0+WtFd/mKWnNYpuTlTzj32wUu/PMmEGOiayQ5UrqgwdBNiaZBtDDh5kddpP7Yg2QaQYA==",
+      "dependencies": {
+        "acorn-private-class-elements": "^0.2.7"
+      },
+      "engines": {
+        "node": ">=4.8.2"
+      },
+      "peerDependencies": {
+        "acorn": "^6.1.0 || ^7 || ^8"
       }
     },
     "node_modules/ajv": {
@@ -7936,6 +8008,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.11.1.tgz",
+      "integrity": "sha512-cksfm5Yb3SyBlm0nZLjLzwxKHKIsdFiF4UFs0ZGrYgF39bOiUMP1h9iTCkrmf6RX2AlR8vRryfjIzwCTMHizdQ=="
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.11.1.tgz",
+      "integrity": "sha512-mmW1q8QjSFan9cDYikgJrxeMdCokTG1igKhREKFlZrUqEkNJu3Zpr0X+K8wFAeDY9OtlZ00/oYoH4wQHTY513Q==",
+      "dependencies": {
+        "hermes-estree": "0.11.1"
       }
     },
     "node_modules/hosted-git-info": {
@@ -14114,6 +14199,14 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/tenko": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tenko/-/tenko-2.0.1.tgz",
+      "integrity": "sha512-oE6Dh8t5i5Cgc0LlogAKotl40wTWLyAn9fMwl5ZMoCUSxj5CFemzBJujy5/9DTFvI+LAsdhf/SYfFMIwUX99ug==",
+      "bin": {
+        "tenko": "t"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -18461,11 +18554,51 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
     },
+    "acorn-class-fields": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.3.7.tgz",
+      "integrity": "sha512-jdUWSFce0fuADUljmExz4TWpPkxmRW/ZCPRqeeUzbGf0vFUcpQYbyq52l75qGd0oSwwtAepeL6hgb/naRgvcKQ==",
+      "requires": {
+        "acorn-private-class-elements": "^0.2.7"
+      }
+    },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "requires": {}
+    },
+    "acorn-private-class-elements": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.7.tgz",
+      "integrity": "sha512-+GZH2wOKNZOBI4OOPmzpo4cs6mW297sn6fgIk1dUI08jGjhAaEwvC39mN2gJAg2lmAQJ1rBkFqKWonL3Zz6PVA==",
+      "requires": {}
+    },
+    "acorn-private-methods": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-private-methods/-/acorn-private-methods-0.3.3.tgz",
+      "integrity": "sha512-46oeEol3YFvLSah5m9hGMlNpxDBCEkdceJgf01AjqKYTK9r6HexKs2rgSbLK81pYjZZMonhftuUReGMlbbv05w==",
+      "requires": {
+        "acorn-private-class-elements": "^0.2.7"
+      }
+    },
+    "acorn-stage3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-stage3/-/acorn-stage3-4.0.0.tgz",
+      "integrity": "sha512-BR+LaADtA6GTB5prkNqWmlmCLYmkyW0whvSxdHhbupTaro2qBJ95fJDEiRLPUmiACGHPaYyeH9xmNJWdGfXRQw==",
+      "requires": {
+        "acorn-class-fields": "^0.3.7",
+        "acorn-private-methods": "^0.3.3",
+        "acorn-static-class-features": "^0.2.4"
+      }
+    },
+    "acorn-static-class-features": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/acorn-static-class-features/-/acorn-static-class-features-0.2.4.tgz",
+      "integrity": "sha512-5X4mpYq5J3pdndLmIB0+WtFd/mKWnNYpuTlTzj32wUu/PMmEGOiayQ5UrqgwdBNiaZBtDDh5kddpP7Yg2QaQYA==",
+      "requires": {
+        "acorn-private-class-elements": "^0.2.7"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -20347,6 +20480,19 @@
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "hermes-estree": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.11.1.tgz",
+      "integrity": "sha512-cksfm5Yb3SyBlm0nZLjLzwxKHKIsdFiF4UFs0ZGrYgF39bOiUMP1h9iTCkrmf6RX2AlR8vRryfjIzwCTMHizdQ=="
+    },
+    "hermes-parser": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.11.1.tgz",
+      "integrity": "sha512-mmW1q8QjSFan9cDYikgJrxeMdCokTG1igKhREKFlZrUqEkNJu3Zpr0X+K8wFAeDY9OtlZ00/oYoH4wQHTY513Q==",
+      "requires": {
+        "hermes-estree": "0.11.1"
       }
     },
     "hosted-git-info": {
@@ -24695,6 +24841,11 @@
           }
         }
       }
+    },
+    "tenko": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tenko/-/tenko-2.0.1.tgz",
+      "integrity": "sha512-oE6Dh8t5i5Cgc0LlogAKotl40wTWLyAn9fMwl5ZMoCUSxj5CFemzBJujy5/9DTFvI+LAsdhf/SYfFMIwUX99ug=="
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14369,9 +14369,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -24965,9 +24965,9 @@
       }
     },
     "typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "peer": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "Convert legacy actions to component actions",
   "main": "index.js",
+  "typings": "index.d.ts",
   "type": "module",
   "scripts": {
     "test": "node --experimental-vm-modules ./node_modules/.bin/jest",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@putout/plugin-remove-empty-pattern": "^4.2.2",
+    "acorn-stage3": "^4.0.0",
     "camelcase": "^7.0.1",
     "csvtojson": "^2.0.10",
     "eslint": "^8.36.0",
@@ -23,6 +24,7 @@
     "eslint-plugin-pipedream": "^0.2.4",
     "eslint-plugin-putout": "^17.1.0",
     "handlebars": "^4.7.7",
+    "hermes-parser": "^0.11.1",
     "inquirer": "^9.1.5",
     "jscodeshift": "^0.14.0",
     "json2csv": "^5.0.6",
@@ -33,6 +35,7 @@
     "prettier": "^2.8.7",
     "putout": "^29.1.5",
     "safe-identifier": "^0.4.2",
+    "tenko": "^2.0.1",
     "varname": "^5.0.1"
   },
   "devDependencies": {

--- a/resources/templates/action-cjs.js
+++ b/resources/templates/action-cjs.js
@@ -1,4 +1,4 @@
-{{#if (isdefined hashId)}}
+export default `{{#if (isdefined hashId)}}
 // legacy_hash_id: {{hashId}}
 {{/if}}
 {{#if defineComponent}}
@@ -64,4 +64,4 @@ module.exports = {
     {{/if}}
     },
   {{/if}}
-{{/inline}}
+{{/inline}}`;

--- a/resources/templates/action-cjs.js
+++ b/resources/templates/action-cjs.js
@@ -13,55 +13,61 @@ module.exports = {
 
 {{~#*inline "componentProperties"}}
 {{#if key}}
-  key: {{tostring key}},
+key: {{tostring key}},
 {{/if}}
 {{#if name}}
-  name: {{tostring name}},
+name: {{tostring name}},
 {{/if}}
 {{#if description}}
-  description: {{tostring description}},
+description: {{tostring description}},
 {{/if}}
 {{#if version}}
-  version: {{tostring version}},
+version: {{tostring version}},
 {{/if}}
 {{#if key}}
-  type: "action",
+type: "action",
 {{/if}}
 {{#if props.[0]}}
-  props: {
-  {{#each props}}
-    {{> componentProp }}
-  {{/each}}
-  },
+props: {
+{{#each props}}
+  {{> componentProp }}
+{{/each}}
+},
 {{/if}}
-  async run({ steps, $ }) {{{code}}}
+async run({ steps, $ }) {
+  {{> runCode}}
+}
+{{/inline}}
+
+{{~#*inline "runCode"}}
+{{{code}}}
 {{/inline}}
 
 {{~#*inline "componentProp"}}
-  {{#if this.isString}}  
-    {{this.key}}: "{{this.type}}",
-  {{else}}
-    {{this.key}}: {
-      type: "{{this.type}}",
-    {{#if this.app}}
-      app: {{tostring this.app}},
-    {{/if}}
-    {{#if (isdefined this.label)}}
-      label: {{{tostring this.label}}},
-    {{/if}}
-    {{#if (isdefined this.description)}}
-      description: {{tostring this.description}},
-    {{/if}}
-    {{#if (isdefined this.optional)}}
-      optional: {{this.optional}},
-    {{/if}}
-    {{#if (isdefined this.options)}}
-      options: [
-      {{#each this.options}}
-        {{tostring this}},
-      {{/each}}
-      ],
-    {{/if}}
-    },
+{{#if this.isString}}  
+{{this.key}}: "{{this.type}}",
+{{else}}
+{{this.key}}: {
+  type: "{{this.type}}",
+  {{#if this.app}}
+  app: {{tostring this.app}},
   {{/if}}
+  {{#if (isdefined this.label)}}
+  label: {{{tostring this.label}}},
+  {{/if}}
+  {{#if (isdefined this.description)}}
+  description: {{tostring this.description}},
+  {{/if}}
+  {{#if (isdefined this.optional)}}
+  optional: {{this.optional}},
+  {{/if}}
+  {{#if (isdefined this.options)}}
+  options: [
+  {{#each this.options}}
+    {{tostring this}},
+  {{/each}}
+  ],
+  {{/if}}
+},
+{{/if}}
 {{/inline}}`;


### PR DESCRIPTION
- Dynamically import Node.js-only modules, ESLint & putout, in Node.js only
- Import the component action handlebars template as a module so it's usable by frontend tooling
- Fix indentation of generated component code
- Fix code config input being required
- Install putout peer dependencies to fix Vite errors
- Add TypeScript declaration file