### PR TITLE
fix(transforms): stop converting event when used as property key

### DIFF
--- a/lib/collections/LegacyAction.js
+++ b/lib/collections/LegacyAction.js
@@ -178,8 +178,11 @@ const traversalMethods = {
         const isMemberProperty =
           types.MemberExpression.check(parent)
           && parent.property === path.node;
-        // must not be a property (e.g., foo.<name>)
-        return !isMemberProperty;
+        const isObjectProperty = 
+          types.Property.check(parent)
+          && parent.key === path.node;
+        // must not be a property (e.g., foo.<name>) or { <name>: value }
+        return !isMemberProperty && !isObjectProperty;
       });
   },
 


### PR DESCRIPTION
For example, the following code was incorrectly converted:

```js
const obj = {
  event: "value"
}
```

to:

```js
const obj = {
  steps.trigger.event: "value"
}
```